### PR TITLE
ci: add pre-commit.yaml

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,0 +1,16 @@
+name: pre-commit
+
+on:
+  pull_request:
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Run pre-commit
+        uses: autowarefoundation/autoware-github-actions/pre-commit@tier4/proposal
+        with:
+          pre-commit-config: .pre-commit-config.yaml


### PR DESCRIPTION
Actually, we don't need this for this repository since we use pre-commit.ci, but I'll add this to copy to other repositories by [sync-files action](https://github.com/autowarefoundation/autoware-github-actions/pull/26).