### PR TITLE
chore: sync autoware.universe

### DIFF
--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -17,3 +17,12 @@
     - source: .yamllint.yaml
     - source: CPPLINT.cfg
     - source: setup.cfg
+
+- repository: autowarefoundation/autoware.universe
+  files:
+    - source: .github/workflows/build-and-test-arm.yaml
+    - source: .github/workflows/build-and-test-arm-pr.yaml
+    - source: .github/workflows/build-and-test.yaml
+    - source: .github/workflows/build-and-test-pr.yaml
+    - source: .github/workflows/check-build-depends.yaml
+    - source: .github/workflows/pre-commit.yaml


### PR DESCRIPTION
To import the changes made in `autoware.universe`, I'll add a cross-reference.

![image](https://user-images.githubusercontent.com/31987104/152551293-f728a580-3035-4e36-99ba-a8084dc2b8cd.png)
