### PR TITLE
ci(build-and-test): ignore CodeCov errors

### DIFF
--- a/.github/workflows/build-and-test-pr.yaml
+++ b/.github/workflows/build-and-test-pr.yaml
@@ -50,7 +50,7 @@ jobs:
         uses: codecov/codecov-action@v2
         with:
           files: lcov/total_coverage.info,coveragepy/.coverage
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           verbose: true
 
   clang-tidy:

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -50,5 +50,5 @@ jobs:
         uses: codecov/codecov-action@v2
         with:
           files: lcov/total_coverage.info,coveragepy/.coverage
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           verbose: true


### PR DESCRIPTION
Changed so that the CodeCov uploader does not throw an error when the upload fails.
This avoids problems when private repositories want to build using this workflow, but do not want to use CodeCov.

Signed-off-by: Keisuke Shima <19993104+KeisukeShima@users.noreply.github.com>