### PR TITLE
ci(build-and-test): do not run if no package was found

### DIFF
--- a/.github/workflows/build-and-test-self-hosted.yaml
+++ b/.github/workflows/build-and-test-self-hosted.yaml
@@ -26,6 +26,7 @@ jobs:
         uses: autowarefoundation/autoware-github-actions/get-self-packages@tier4/proposal
 
       - name: Build and test
+        if: ${{ steps.get-self-packages.outputs.self-packages != '' }}
         uses: autowarefoundation/autoware-github-actions/colcon-build-and-test@tier4/proposal
         with:
           rosdistro: galactic

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -28,6 +28,7 @@ jobs:
         uses: autowarefoundation/autoware-github-actions/get-self-packages@tier4/proposal
 
       - name: Build and test
+        if: ${{ steps.get-self-packages.outputs.self-packages != '' }}
         uses: autowarefoundation/autoware-github-actions/colcon-build-and-test@tier4/proposal
         with:
           rosdistro: galactic


### PR DESCRIPTION
Resolves this error: https://github.com/autowarefoundation/autoware-github-actions/pull/68/files#r804486016