### PR TITLE
ci(check-build-depends): remove tests to make it faster

### DIFF
--- a/.github/workflows/check-build-depends.yaml
+++ b/.github/workflows/check-build-depends.yaml
@@ -29,10 +29,3 @@ jobs:
           rosdistro: galactic
           target-packages: ${{ steps.get-self-packages.outputs.self-packages }}
           build-depends-repos: build_depends.repos
-
-      - name: Test
-        uses: autowarefoundation/autoware-github-actions/colcon-test@tier4/proposal
-        with:
-          rosdistro: galactic
-          target-packages: ${{ steps.get-self-packages.outputs.self-packages }}
-          build-depends-repos: build_depends.repos


### PR DESCRIPTION
Since this workflow just checks the build, the `Test` job isn't necessary.