### PR TITLE
feat: add autoware_cmake package

### DIFF
--- a/autoware_cmake/CMakeLists.txt
+++ b/autoware_cmake/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(autoware_cmake NONE)
+
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
+
+list(APPEND ${PROJECT_NAME}_CONFIG_EXTRAS
+  "autoware_cmake-extras.cmake"
+)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_auto_package(
+  INSTALL_TO_SHARE
+    cmake
+)

--- a/autoware_cmake/README.md
+++ b/autoware_cmake/README.md
@@ -1,0 +1,19 @@
+# autoware_cmake
+
+This package provides CMake scripts for Autoware.
+
+## Usage
+
+### autoware_package.cmake
+
+Call `autoware_package()` before defining build targets, which will set common options for Autoware.
+
+```cmake
+cmake_minimum_required(VERSION 3.5)
+project(package_name)
+
+find_package(autoware_cmake REQUIRED)
+autoware_package()
+
+ament_auto_add_library(...)
+```

--- a/autoware_cmake/autoware_cmake-extras.cmake
+++ b/autoware_cmake/autoware_cmake-extras.cmake
@@ -1,0 +1,15 @@
+# Copyright 2022 The Autoware Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include("${autoware_cmake_DIR}/autoware_package.cmake")

--- a/autoware_cmake/cmake/autoware_package.cmake
+++ b/autoware_cmake/cmake/autoware_package.cmake
@@ -1,0 +1,45 @@
+# Copyright 2022 The Autoware Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+macro(autoware_package)
+  # Set compile options
+  if(NOT CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD 17)
+    set(CMAKE_CXX_STANDARD_REQUIRED ON)
+    set(CMAKE_CXX_EXTENSIONS OFF)
+  endif()
+  if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    add_compile_options(-Wall -Wextra -Wpedantic -Werror)
+  endif()
+
+  # Set ROS_DISTRO macros
+  set(ROS_DISTRO $ENV{ROS_DISTRO})
+  if(${ROS_DISTRO} STREQUAL "rolling")
+    add_definitions(-DROS_DISTRO_ROLLING)
+  elseif(${ROS_DISTRO} STREQUAL "galactic")
+    add_definitions(-DROS_DISTRO_GALACTIC)
+  elseif(${ROS_DISTRO} STREQUAL "humble")
+    add_definitions(-DROS_DISTRO_HUMBLE)
+  endif()
+
+  # Find dependencies
+  find_package(ament_cmake_auto REQUIRED)
+  ament_auto_find_build_dependencies()
+
+  # Find test dependencies
+  if(BUILD_TESTING)
+    find_package(ament_lint_auto REQUIRED)
+    ament_lint_auto_find_test_dependencies()
+  endif()
+endmacro()

--- a/autoware_cmake/package.xml
+++ b/autoware_cmake/package.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>autoware_cmake</name>
+  <version>0.1.0</version>
+  <description>CMake scripts for Autoware</description>
+  <maintainer email="kenji.miyake@tier4.jp">Kenji Miyake</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>autoware_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

As I commented in https://github.com/autowarefoundation/autoware.universe/pull/762#discussion_r855682896, it's useful if we can set `ROS_DISTRO` macros and other compile options in common.

This is a simplified version of `autoware_auto_cmake`.
https://gitlab.com/autowarefoundation/autoware.auto/AutowareAuto/-/tree/master/src/tools/autoware_auto_cmake
https://github.com/autowarefoundation/autoware.universe/tree/main/common/autoware_auto_cmake

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
