### PR TITLE
feat(autoware_cmake): ignore Boost deprecated messages

### DIFF
--- a/autoware_cmake/CMakeLists.txt
+++ b/autoware_cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 
 project(autoware_cmake NONE)
 

--- a/autoware_cmake/cmake/autoware_package.cmake
+++ b/autoware_cmake/cmake/autoware_package.cmake
@@ -28,14 +28,17 @@ macro(autoware_package)
     add_compile_options(-Wno-gnu-anonymous-struct -Wno-nested-anon-types)
   endif()
 
+  # Ignore Boost deprecated messages
+  add_compile_definitions(BOOST_ALLOW_DEPRECATED_HEADERS)
+
   # Set ROS_DISTRO macros
   set(ROS_DISTRO $ENV{ROS_DISTRO})
   if(${ROS_DISTRO} STREQUAL "rolling")
-    add_definitions(-DROS_DISTRO_ROLLING)
+    add_compile_definitions(ROS_DISTRO_ROLLING)
   elseif(${ROS_DISTRO} STREQUAL "galactic")
-    add_definitions(-DROS_DISTRO_GALACTIC)
+    add_compile_definitions(ROS_DISTRO_GALACTIC)
   elseif(${ROS_DISTRO} STREQUAL "humble")
-    add_definitions(-DROS_DISTRO_HUMBLE)
+    add_compile_definitions(ROS_DISTRO_HUMBLE)
   endif()
 
   # Find dependencies

--- a/autoware_lint_common/CMakeLists.txt
+++ b/autoware_lint_common/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 
 project(autoware_lint_common NONE)
 


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

Defined a macro `BOOST_ALLOW_DEPRECATED_HEADERS` to ignore Boost deprecated messages.
According to [this comment](https://stackoverflow.com/questions/66906613/how-to-silence-internal-boost-deprecated-messages#comment118269576_66906613), it seems there are no other ways for now? :thinking: 

References:
- https://www.boost.org/doc/libs/1_68_0/libs/config/doc/html/boost_config/boost_macro_reference.html
- https://stackoverflow.com/questions/66906613/how-to-silence-internal-boost-deprecated-messages

![image](https://user-images.githubusercontent.com/31987104/166970345-d602b66e-86f7-4e66-ab6d-059a4b473cf3.png)

Also, `add_definitions` was replaced by `add_compile_definitions`
https://cmake.org/cmake/help/latest/command/add_definitions.html

Related: https://github.com/autowarefoundation/autoware.universe/pull/856

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
