### PR TITLE
chore: ignore unnecessary CMake warnings

### DIFF
--- a/autoware_cmake/cmake/autoware_package.cmake
+++ b/autoware_cmake/cmake/autoware_package.cmake
@@ -31,6 +31,9 @@ macro(autoware_package)
   # Ignore Boost deprecated messages
   add_compile_definitions(BOOST_ALLOW_DEPRECATED_HEADERS)
 
+  # Ignore unnecessary CMake warnings
+  set(__dummy__ ${CMAKE_EXPORT_COMPILE_COMMANDS})
+
   # Set ROS_DISTRO macros
   set(ROS_DISTRO $ENV{ROS_DISTRO})
   if(${ROS_DISTRO} STREQUAL "rolling")


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

Ignored this kind of warning.

```
--- stderr: tier4_system_launch
CMake Warning:
  Manually-specified variables were not used by the project:

    CMAKE_EXPORT_COMPILE_COMMANDS
```

Reference: https://stackoverflow.com/questions/36451368/get-rid-of-cmake-warning-manually-specified-variables-were-not-used-by-the-proj

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
