### PR TITLE
ci: use ros image to speed up CI

### DIFF
--- a/.github/workflows/build-and-test-differential-self-hosted.yaml
+++ b/.github/workflows/build-and-test-differential-self-hosted.yaml
@@ -18,7 +18,7 @@ jobs:
     needs: prevent-no-label-execution
     if: ${{ needs.prevent-no-label-execution.outputs.run == 'true' }}
     runs-on: [self-hosted, linux, ARM64]
-    container: ghcr.io/autowarefoundation/autoware-universe:latest
+    container: ros:galactic
     steps:
       - name: Check out repository
         uses: actions/checkout@v3

--- a/.github/workflows/build-and-test-differential.yaml
+++ b/.github/workflows/build-and-test-differential.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   build-and-test-differential:
     runs-on: ubuntu-latest
-    container: ghcr.io/autowarefoundation/autoware-universe:latest
+    container: ros:galactic
     steps:
       - name: Cancel previous runs
         uses: styfle/cancel-workflow-action@0.9.1

--- a/.github/workflows/build-and-test-self-hosted.yaml
+++ b/.github/workflows/build-and-test-self-hosted.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   build-and-test-self-hosted:
     runs-on: [self-hosted, linux, ARM64]
-    container: ghcr.io/autowarefoundation/autoware-universe:latest
+    container: ros:galactic
     steps:
       - name: Check out repository
         uses: actions/checkout@v3

--- a/.github/workflows/build-and-test-with-reverse-depends.yaml
+++ b/.github/workflows/build-and-test-with-reverse-depends.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   build-and-test-with-reverse-depends:
     runs-on: ubuntu-latest
-    container: ghcr.io/autowarefoundation/autoware-universe:latest
+    container: ros:galactic
     steps:
       - name: Check out repository
         uses: actions/checkout@v3

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -10,7 +10,7 @@ jobs:
   build-and-test:
     if: ${{ github.event_name != 'push' || github.ref_name == github.event.repository.default_branch }}
     runs-on: ubuntu-latest
-    container: ghcr.io/autowarefoundation/autoware-universe:latest
+    container: ros:galactic
     steps:
       - name: Check out repository
         uses: actions/checkout@v3

--- a/.github/workflows/check-build-depends.yaml
+++ b/.github/workflows/check-build-depends.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   check-build-depends:
     runs-on: ubuntu-latest
-    container: ghcr.io/autowarefoundation/autoware-universe:latest
+    container: ros:galactic
     steps:
       - name: Cancel previous runs
         uses: styfle/cancel-workflow-action@0.9.1


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

I've used Autoware's image, considering that `autoware.universe` depends on CUDA.
But now, the dependency on Autoware's image can be removed by [this feature](https://github.com/autowarefoundation/autoware-github-actions/pull/149).
It enables us to change the container option when `sync-file` is executed.

So I'll change the sync settings and use Autoware's image only for `autoware.universe`.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
