### PR TITLE
feat: fork ament_cmake_auto package for ament/ament_cmake#385

### DIFF
--- a/ament_cmake_auto/CHANGELOG.rst
+++ b/ament_cmake_auto/CHANGELOG.rst
@@ -1,0 +1,155 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package ament_cmake_auto
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+1.3.2 (2022-05-17)
+------------------
+
+1.3.1 (2022-03-28)
+------------------
+
+1.3.0 (2022-02-17)
+------------------
+* Update forthcoming version in changelog
+* Contributors: Audrow Nash
+
+1.2.1 (2022-01-14)
+------------------
+* Fix typo in ament_auto_find_test_dependencies (`#363 <https://github.com/ament/ament_cmake/issues/363>`_)
+* Update maintainers to Michael Jeronimo and Michel Hidalgo (`#362 <https://github.com/ament/ament_cmake/issues/362>`_)
+* Contributors: Audrow Nash, Daisuke Nishimatsu
+
+1.2.0 (2021-10-29)
+------------------
+* Add ament_auto_add_gtest (`#344 <https://github.com/ament/ament_cmake/issues/344>`_)
+* Use FindPython3 instead of FindPythonInterp (`#355 <https://github.com/ament/ament_cmake/issues/355>`_)
+* Update maintainers (`#336 <https://github.com/ament/ament_cmake/issues/336>`_)
+* Contributors: Chris Lalancette, Joshua Whitley, Shane Loretz
+
+1.1.4 (2021-05-06)
+------------------
+
+1.1.3 (2021-03-09)
+------------------
+
+1.1.2 (2021-02-26 22:59)
+------------------------
+
+1.1.1 (2021-02-26 19:12)
+------------------------
+
+1.1.0 (2021-02-24)
+------------------
+
+1.0.4 (2021-01-25)
+------------------
+
+1.0.3 (2020-12-10)
+------------------
+
+1.0.2 (2020-12-07)
+------------------
+* Update package maintainers. (`#286 <https://github.com/ament/ament_cmake/issues/286>`_)
+* Contributors: Michel Hidalgo
+
+1.0.1 (2020-09-10)
+------------------
+
+1.0.0 (2020-07-22)
+------------------
+
+0.9.6 (2020-06-23)
+------------------
+
+0.9.5 (2020-06-02)
+------------------
+
+0.9.4 (2020-05-26)
+------------------
+
+0.9.3 (2020-05-19)
+------------------
+
+0.9.2 (2020-05-07)
+------------------
+
+0.9.1 (2020-04-24 15:45)
+------------------------
+
+0.9.0 (2020-04-24 12:25)
+------------------------
+
+0.8.1 (2019-10-23)
+------------------
+
+0.8.0 (2019-10-04)
+------------------
+* pass unparsed argument of ament_auto_package() to ament_package() (`#194 <https://github.com/ament/ament_cmake/issues/194>`_)
+* Contributors: Dirk Thomas
+
+0.7.3 (2019-05-29)
+------------------
+
+0.7.2 (2019-05-20)
+------------------
+
+0.7.1 (2019-05-07)
+------------------
+* Add option to ament_auto_package to install to share folder: (`#166 <https://github.com/ament/ament_cmake/issues/166>`_)
+  - This will simplify installing folders like 'cmake' and 'launch'
+  into a package's shared folder
+* Contributors: jpsamper2009
+
+0.7.0 (2019-04-08)
+------------------
+
+0.6.0 (2018-11-13)
+------------------
+
+0.5.1 (2018-07-17)
+------------------
+
+0.5.0 (2018-06-13)
+------------------
+
+0.4.0 (2017-12-08)
+------------------
+* 0.0.3
+* Install ament_cmake_auto executables to libexec by default (`#97 <https://github.com/ament/ament_cmake/issues/97>`_)
+  * Install ament_cmake_auto executables to libexec by default
+  * update docblock
+  * simplify installing executables
+* 0.0.2
+* Add optional list of required packages for ament_auto_find_build_dependencies (`#93 <https://github.com/ament/ament_cmake/issues/93>`_)
+  * Add optional list of required packages
+  * Prefix ARG variables + fixup
+  * REQUIRED_PACKAGES -> REQUIRED
+  * Output all ignored packages at once
+  * Pass REQUIRED in addition to QUIET, not instead of
+  * _ignored_pacakges -> _additional_packages
+  * De-duplicate the find_package call
+  * rename var and small changes
+* Merge pull request `#86 <https://github.com/ament/ament_cmake/issues/86>`_ from ament/remove_include
+  remove unnecessary include
+* remove unnecessary include
+* Merge pull request `#84 <https://github.com/ament/ament_cmake/issues/84>`_ from ament/use_in_list
+  use IN_LIST
+* use IN_LIST
+* update schema url
+* add schema to manifest files
+* Merge pull request `#72 <https://github.com/ament/ament_cmake/issues/72>`_ from ament/cmake35
+  require CMake 3.5
+* remove trailing spaces from comparisons, obsolete quotes and explicit variable expansion
+* require CMake 3.5
+* add explicit build type
+* disable debug output
+* add missing copyright / license information, update format of existing license information
+* Merge pull request `#3 <https://github.com/ament/ament_cmake/issues/3>`_ from ament/windows
+  Windows Support
+* [windows] fixed installation of dll's
+* use project(.. NONE)
+* deal with CMake double expansion
+* add ament_cmake_libraries
+* update cmake code style
+* add ament_cmake_auto
+* Contributors: Dirk Thomas, William Woodall, dhood

--- a/ament_cmake_auto/CMakeLists.txt
+++ b/ament_cmake_auto/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.12)
+
+project(ament_cmake_auto NONE)
+
+find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_gtest REQUIRED)
+
+ament_package(
+  CONFIG_EXTRAS "ament_cmake_auto-extras.cmake"
+)
+
+install(
+  DIRECTORY cmake
+  DESTINATION share/${PROJECT_NAME}
+)

--- a/ament_cmake_auto/ament_cmake_auto-extras.cmake
+++ b/ament_cmake_auto/ament_cmake_auto-extras.cmake
@@ -1,0 +1,25 @@
+# Copyright 2014 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# copied from ament_cmake_auto/ament_cmake_auto-extras.cmake
+
+find_package(ament_cmake QUIET REQUIRED)
+
+include("${ament_cmake_auto_DIR}/ament_auto_add_executable.cmake")
+include("${ament_cmake_auto_DIR}/ament_auto_add_gtest.cmake")
+include("${ament_cmake_auto_DIR}/ament_auto_add_library.cmake")
+include("${ament_cmake_auto_DIR}/ament_auto_generate_code.cmake")
+include("${ament_cmake_auto_DIR}/ament_auto_find_build_dependencies.cmake")
+include("${ament_cmake_auto_DIR}/ament_auto_find_test_dependencies.cmake")
+include("${ament_cmake_auto_DIR}/ament_auto_package.cmake")

--- a/ament_cmake_auto/cmake/ament_auto_add_executable.cmake
+++ b/ament_cmake_auto/cmake/ament_auto_add_executable.cmake
@@ -1,0 +1,87 @@
+# Copyright 2014 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Add an executable target.
+#
+# All arguments of the CMake function ``add_executable()`` can be
+# used beside the custom arguments ``DIRECTORY`` and
+# ``NO_TARGET_LINK_LIBRARIES``.
+#
+# :param target: the name of the executable target
+# :type target: string
+# :param DIRECTORY: the directory to recursively glob for source
+#   files with the following extensions: c, cc, cpp, cxx
+# :type DIRECTORY: string
+# :param NO_TARGET_LINK_LIBRARIES: if set skip linking against
+#   ``${PROJECT_NAME}_LIBRARIES``
+# :type NO_TARGET_LINK_LIBRARIES: option
+#
+# Append the target to the ``${PROJECT_NAME}_EXECUTABLES`` variable.
+#
+# @public
+#
+macro(ament_auto_add_executable target)
+  cmake_parse_arguments(ARG
+    "WIN32;MACOSX_BUNDLE;EXCLUDE_FROM_ALL;NO_TARGET_LINK_LIBRARIES"
+    "DIRECTORY"
+    ""
+    ${ARGN})
+  if(NOT ARG_DIRECTORY AND NOT ARG_UNPARSED_ARGUMENTS)
+    message(FATAL_ERROR "ament_auto_add_executable() called without any "
+      "source files and without a DIRECTORY argument")
+  endif()
+
+  set(_source_files "")
+  if(ARG_DIRECTORY)
+    # glob all source files
+    file(
+      GLOB_RECURSE
+      _source_files
+      RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}"
+      "${ARG_DIRECTORY}/*.c"
+      "${ARG_DIRECTORY}/*.cc"
+      "${ARG_DIRECTORY}/*.cpp"
+      "${ARG_DIRECTORY}/*.cxx"
+    )
+    if(NOT _source_files)
+      message(FATAL_ERROR "ament_auto_add_executable() no source files found "
+        "in directory '${CMAKE_CURRENT_SOURCE_DIR}/${ARG_DIRECTORY}'")
+    endif()
+  endif()
+
+  # parse again to "remove" custom arguments
+  cmake_parse_arguments(ARG "NO_TARGET_LINK_LIBRARIES" "DIRECTORY" "" ${ARGN})
+  add_executable("${target}" ${ARG_UNPARSED_ARGUMENTS} ${_source_files})
+
+  # add include directory of this package if it exists
+  if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/include")
+    target_include_directories("${target}" PUBLIC
+      "${CMAKE_CURRENT_SOURCE_DIR}/include")
+  endif()
+  # link against other libraries of this package
+  if(NOT ${PROJECT_NAME}_LIBRARIES STREQUAL "" AND
+      NOT ARG_NO_TARGET_LINK_LIBRARIES)
+    foreach(lib ${${PROJECT_NAME}_LIBRARIES})
+      get_target_property(lib_include_dirs ${lib} INTERFACE_INCLUDE_DIRECTORIES)
+      target_include_directories("${target}" SYSTEM PRIVATE ${lib_include_dirs})
+      target_link_libraries("${target}" ${lib})
+    endforeach(lib)
+  endif()
+
+  # add exported information from found build dependencies
+  ament_target_dependencies(${target} SYSTEM ${${PROJECT_NAME}_FOUND_BUILD_DEPENDS})
+
+  list(APPEND ${PROJECT_NAME}_EXECUTABLES "${target}")
+endmacro()

--- a/ament_cmake_auto/cmake/ament_auto_add_gtest.cmake
+++ b/ament_cmake_auto/cmake/ament_auto_add_gtest.cmake
@@ -1,0 +1,112 @@
+# Copyright 2021 Whitley Software Services, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Add a gtest with all found test dependencies.
+#
+# Call add_executable(target ARGN), link it against the gtest libraries
+# and all found test dependencies, and then register the executable as a test.
+#
+# If gtest is not available the specified target is not being created and
+# therefore the target existence should be checked before being used.
+#
+# :param target: the target name which will also be used as the test name
+# :type target: string
+# :param ARGN: the list of source files
+# :type ARGN: list of strings
+# :param RUNNER: the path to the test runner script (default:
+#   see ament_add_test).
+# :type RUNNER: string
+# :param TIMEOUT: the test timeout in seconds,
+#   default defined by ``ament_add_test()``
+# :type TIMEOUT: integer
+# :param WORKING_DIRECTORY: the working directory for invoking the
+#   executable in, default defined by ``ament_add_test()``
+# :type WORKING_DIRECTORY: string
+# :param SKIP_LINKING_MAIN_LIBRARIES: if set skip linking against the gtest
+#   main libraries
+# :type SKIP_LINKING_MAIN_LIBRARIES: option
+# :param SKIP_TEST: if set mark the test as being skipped
+# :type SKIP_TEST: option
+# :param ENV: list of env vars to set; listed as ``VAR=value``
+# :type ENV: list of strings
+# :param APPEND_ENV: list of env vars to append if already set, otherwise set;
+#   listed as ``VAR=value``
+# :type APPEND_ENV: list of strings
+# :param APPEND_LIBRARY_DIRS: list of library dirs to append to the appropriate
+#   OS specific env var, a la LD_LIBRARY_PATH
+# :type APPEND_LIBRARY_DIRS: list of strings
+#
+# @public
+#
+macro(ament_auto_add_gtest target)
+  cmake_parse_arguments(_ARGN
+    "SKIP_LINKING_MAIN_LIBRARIES;SKIP_TEST"
+    "RUNNER;TIMEOUT;WORKING_DIRECTORY"
+    "APPEND_ENV;APPEND_LIBRARY_DIRS;ENV"
+    ${ARGN})
+  if(NOT _ARGN_UNPARSED_ARGUMENTS)
+    message(FATAL_ERROR
+      "ament_auto_add_gtest() must be invoked with at least one source file")
+  endif()
+
+  # add executable
+  set(_argn_executable ${_ARGN_UNPARSED_ARGUMENTS})
+  if(_ARG_SKIP_LINKING_MAIN_LIBRARIES)
+    list(APPEND _argn_executable "SKIP_LINKING_MAIN_LIBRARIES")
+  endif()
+  ament_add_gtest_executable("${target}" ${_argn_executable})
+
+  # add include directory of this package if it exists
+  if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/include")
+    target_include_directories("${target}" PUBLIC
+      "${CMAKE_CURRENT_SOURCE_DIR}/include")
+  endif()
+
+  # link against other libraries of this package
+  if(NOT ${PROJECT_NAME}_LIBRARIES STREQUAL "")
+    target_link_libraries("${target}" ${${PROJECT_NAME}_LIBRARIES})
+  endif()
+
+  # add exported information from found dependencies
+  ament_target_dependencies(${target}
+    ${${PROJECT_NAME}_FOUND_BUILD_DEPENDS}
+    ${${PROJECT_NAME}_FOUND_TEST_DEPENDS}
+  )
+
+  # add test
+  set(_argn_test "")
+  if(_ARG_RUNNER)
+    list(APPEND _argn_test "RUNNER" "${_ARG_RUNNER}")
+  endif()
+  if(_ARG_TIMEOUT)
+    list(APPEND _argn_test "TIMEOUT" "${_ARG_TIMEOUT}")
+  endif()
+  if(_ARG_WORKING_DIRECTORY)
+    list(APPEND _argn_test "WORKING_DIRECTORY" "${_ARG_WORKING_DIRECTORY}")
+  endif()
+  if(_ARG_SKIP_TEST)
+    list(APPEND _argn_test "SKIP_TEST")
+  endif()
+  if(_ARG_ENV)
+    list(APPEND _argn_test "ENV" ${_ARG_ENV})
+  endif()
+  if(_ARG_APPEND_ENV)
+    list(APPEND _argn_test "APPEND_ENV" ${_ARG_APPEND_ENV})
+  endif()
+  if(_ARG_APPEND_LIBRARY_DIRS)
+    list(APPEND _argn_test "APPEND_LIBRARY_DIRS" ${_ARG_APPEND_LIBRARY_DIRS})
+  endif()
+  ament_add_gtest_test("${target}" ${_argn_test})
+endmacro()

--- a/ament_cmake_auto/cmake/ament_auto_add_library.cmake
+++ b/ament_cmake_auto/cmake/ament_auto_add_library.cmake
@@ -1,0 +1,87 @@
+# Copyright 2014 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Add a library target.
+#
+# All arguments of the CMake function ``add_library()`` can be used
+# beside the custom arguments ``DIRECTORY`` and
+# ``NO_TARGET_LINK_LIBRARIES``.
+#
+# :param target: the name of the library target
+# :type target: string
+# :param DIRECTORY: the directory to recursively glob for source
+#   files with the following extensions: c, cc, cpp, cxx
+# :type DIRECTORY: string
+# :param NO_TARGET_LINK_LIBRARIES: if set skip linking against
+#   ``${PROJECT_NAME}_LIBRARIES``
+# :type NO_TARGET_LINK_LIBRARIES: option
+#
+# Append the target to the ``${PROJECT_NAME}_LIBRARIES`` variable.
+#
+# @public
+#
+macro(ament_auto_add_library target)
+  cmake_parse_arguments(ARG
+    "STATIC;SHARED;MODULE;EXCLUDE_FROM_ALL;NO_TARGET_LINK_LIBRARIES"
+    "DIRECTORY"
+    ""
+    ${ARGN})
+  if(NOT ARG_DIRECTORY AND NOT ARG_UNPARSED_ARGUMENTS)
+    message(FATAL_ERROR "ament_auto_add_library() called without any source "
+      "files and without a DIRECTORY argument")
+  endif()
+
+  set(_source_files "")
+  if(ARG_DIRECTORY)
+    # glob all source files
+    file(
+      GLOB_RECURSE
+      _source_files
+      RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}"
+      "${ARG_DIRECTORY}/*.c"
+      "${ARG_DIRECTORY}/*.cc"
+      "${ARG_DIRECTORY}/*.cpp"
+      "${ARG_DIRECTORY}/*.cxx"
+    )
+    if(NOT _source_files)
+      message(FATAL_ERROR "ament_auto_add_library() no source files found in "
+        "directory '${CMAKE_CURRENT_SOURCE_DIR}/${ARG_DIRECTORY}'")
+    endif()
+  endif()
+
+  # parse again to "remove" custom arguments
+  cmake_parse_arguments(ARG "NO_TARGET_LINK_LIBRARIES" "DIRECTORY" "" ${ARGN})
+  add_library("${target}" ${ARG_UNPARSED_ARGUMENTS} ${_source_files})
+
+  # add include directory of this package if it exists
+  if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/include")
+    target_include_directories("${target}" PUBLIC
+      "${CMAKE_CURRENT_SOURCE_DIR}/include")
+  endif()
+  # link against other libraries of this package
+  if(NOT ${PROJECT_NAME}_LIBRARIES STREQUAL "" AND
+      NOT ARG_NO_TARGET_LINK_LIBRARIES)
+    foreach(lib ${${PROJECT_NAME}_LIBRARIES})
+      get_target_property(lib_include_dirs ${lib} INTERFACE_INCLUDE_DIRECTORIES)
+      target_include_directories("${target}" SYSTEM PRIVATE ${lib_include_dirs})
+      target_link_libraries("${target}" ${lib})
+    endforeach(lib)
+  endif()
+
+  # add exported information from found build dependencies
+  ament_target_dependencies(${target} SYSTEM ${${PROJECT_NAME}_FOUND_BUILD_DEPENDS})
+
+  list(APPEND ${PROJECT_NAME}_LIBRARIES "${target}")
+endmacro()

--- a/ament_cmake_auto/cmake/ament_auto_find_build_dependencies.cmake
+++ b/ament_cmake_auto/cmake/ament_auto_find_build_dependencies.cmake
@@ -1,0 +1,88 @@
+# Copyright 2014 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Invoke find_package() for all build and buildtool dependencies.
+#
+# :param REQUIRED: an optional list of package names that are known
+# required CMake dependencies. For these dependencies, find_package() will be
+# invoked with REQUIRED.
+# :type REQUIRED: list of strings
+#
+# All found package names are appended to the
+# ``${PROJECT_NAME}_FOUND_BUILD_DEPENDS`` /
+# ``${PROJECT_NAME}_FOUND_BUILDTOOL_DEPENDS`` variables.
+#
+# The content of the package specific variables of build dependencies
+# ending with ``_DEFINITIONS``, ``_INCLUDE_DIRS`` and ``_LIBRARIES``
+# are appended to the same variables starting with
+# ``${PROJECT_NAME}_FOUND_``.
+#
+# @public
+#
+macro(ament_auto_find_build_dependencies)
+  cmake_parse_arguments(_ARG "" "" "REQUIRED" ${ARGN})
+  if(_ARG_UNPARSED_ARGUMENTS)
+    message(FATAL_ERROR "ament_auto_find_build_dependencies() called with "
+      "unused arguments: ${_ARG_UNPARSED_ARGUMENTS}")
+  endif()
+
+  if(NOT _AMENT_PACKAGE_NAME)
+    ament_package_xml()
+  endif()
+
+  # ensure that the caller isn't expecting packages not listed in the manifest
+  set(_unknown_packages "")
+  foreach(_package_name ${_ARG_REQUIRED})
+    if(NOT _package_name IN_LIST ${PROJECT_NAME}_BUILD_DEPENDS AND
+      NOT _package_name IN_LIST ${PROJECT_NAME}_BUILDTOOL_DEPENDS
+    )
+      list(APPEND _unknown_packages ${_package_name})
+    endif()
+  endforeach()
+  if(_unknown_packages)
+    string(REPLACE ";" ", " _unknown_packages_str "${_unknown_packages}")
+    message(FATAL_ERROR "ament_auto_find_build_dependencies() called with "
+      "required packages that are not listed as a build/buildtool dependency "
+      "in the package.xml: ${_unknown_packages_str}")
+  endif()
+
+  # try to find_package() all build dependencies
+  foreach(_dep ${${PROJECT_NAME}_BUILD_DEPENDS})
+    set(_REQUIRED_KEYWORD "")
+    if(_dep IN_LIST _ARG_REQUIRED)
+      set(_REQUIRED_KEYWORD "REQUIRED")
+    endif()
+    find_package(${_dep} QUIET ${_REQUIRED_KEYWORD})
+    if(${_dep}_FOUND)
+      list(APPEND ${PROJECT_NAME}_FOUND_BUILD_DEPENDS ${_dep})
+
+      list(APPEND ${PROJECT_NAME}_FOUND_DEFINITIONS ${${_dep}_DEFINITIONS})
+      list(APPEND ${PROJECT_NAME}_FOUND_INCLUDE_DIRS ${${_dep}_INCLUDE_DIRS})
+      list(APPEND ${PROJECT_NAME}_FOUND_LIBRARIES ${${_dep}_LIBRARIES})
+    endif()
+  endforeach()
+
+  # try to find_package() all buildtool dependencies
+  foreach(_dep ${${PROJECT_NAME}_BUILDTOOL_DEPENDS})
+    set(_REQUIRED_KEYWORD "")
+    if(_dep IN_LIST _ARG_REQUIRED)
+      set(_REQUIRED_KEYWORD "REQUIRED")
+    endif()
+    find_package(${_dep} QUIET ${_REQUIRED_KEYWORD})
+    if(${_dep}_FOUND)
+      list(APPEND ${PROJECT_NAME}_FOUND_BUILDTOOL_DEPENDS ${_dep})
+    endif()
+  endforeach()
+endmacro()

--- a/ament_cmake_auto/cmake/ament_auto_find_test_dependencies.cmake
+++ b/ament_cmake_auto/cmake/ament_auto_find_test_dependencies.cmake
@@ -1,0 +1,41 @@
+# Copyright 2021 Whitley Software Services, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Invoke find_package() for all test dependencies.
+#
+# All found package names are appended to the
+# ``${PROJECT_NAME}_FOUND_TEST_DEPENDS`` variables.
+#
+# @public
+#
+macro(ament_auto_find_test_dependencies)
+  set(_ARGN "${ARGN}")
+  if(_ARGN)
+    message(FATAL_ERROR "ament_auto_find_test_dependencies() called with "
+      "unused arguments: ${_ARGN}")
+  endif()
+
+  if(NOT _AMENT_PACKAGE_NAME)
+    ament_package_xml()
+  endif()
+
+  # try to find_package() all test dependencies
+  foreach(_dep ${${PROJECT_NAME}_TEST_DEPENDS})
+    find_package(${_dep} QUIET)
+    if(${_dep}_FOUND)
+      list(APPEND ${PROJECT_NAME}_FOUND_TEST_DEPENDS ${_dep})
+    endif()
+  endforeach()
+endmacro()

--- a/ament_cmake_auto/cmake/ament_auto_generate_code.cmake
+++ b/ament_cmake_auto/cmake/ament_auto_generate_code.cmake
@@ -1,0 +1,22 @@
+# Copyright 2014 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Execute the extension point ``ament_auto_generate_code``.
+#
+# @public
+#
+macro(ament_auto_generate_code)
+  ament_execute_extensions(ament_auto_generate_code)
+endmacro()

--- a/ament_cmake_auto/cmake/ament_auto_package.cmake
+++ b/ament_cmake_auto/cmake/ament_auto_package.cmake
@@ -1,0 +1,103 @@
+# Copyright 2014 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Export information, install files and targets, execute the
+# extension point ``ament_auto_package`` and invoke
+# ``ament_package()``.
+#
+# :param INSTALL_TO_PATH: if set, install executables to `bin` so that
+#   they are available on the `PATH`.
+#   By default they are being installed into `lib/${PROJECT_NAME}`.
+#   It is currently not possible to install some executable into `bin`
+#   and some into `lib/${PROJECT_NAME}`.
+#   Libraries are not affected by this option.
+#   They are always installed into `lib` and `dll`s into `bin`.
+# :type INSTALL_TO_PATH: option
+# :param INSTALL_TO_SHARE: a list of directories to be installed to the
+#   package's share directory
+# :type INSTALL_TO_SHARE: list of strings
+# :param ARGN: any other arguments are passed through to ament_package()
+# :type ARGN: list of strings
+#
+# Export all found build dependencies which are also run
+# dependencies.
+# If the package has an include directory install all recursively
+# found header files (ending in h, hh, hpp, hxx) and export the
+# include directory.
+# Export and install all library targets and install all executable
+# targets.
+#
+# @public
+#
+
+macro(ament_auto_package)
+  cmake_parse_arguments(_ARG "INSTALL_TO_PATH" "" "INSTALL_TO_SHARE" ${ARGN})
+  # passing all unparsed arguments to ament_package()
+
+  # export all found build dependencies which are also run dependencies
+  set(_run_depends
+    ${${PROJECT_NAME}_BUILD_EXPORT_DEPENDS}
+    ${${PROJECT_NAME}_BUILDTOOL_EXPORT_DEPENDS}
+    ${${PROJECT_NAME}_EXEC_DEPENDS})
+  foreach(_dep
+      ${${PROJECT_NAME}_FOUND_BUILD_DEPENDS}
+      ${${PROJECT_NAME}_FOUND_BUILDTOOL_DEPENDS})
+    if(_dep IN_LIST _run_depends)
+      ament_export_dependencies("${_dep}")
+    endif()
+  endforeach()
+
+  # export and install include directory of this package if it has one
+  if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/include")
+    ament_export_include_directories("include")
+    install(DIRECTORY include/ DESTINATION include)
+  endif()
+
+  # export and install all libraries
+  if(NOT ${PROJECT_NAME}_LIBRARIES STREQUAL "")
+    ament_export_libraries(${${PROJECT_NAME}_LIBRARIES})
+    install(
+      TARGETS ${${PROJECT_NAME}_LIBRARIES}
+      ARCHIVE DESTINATION lib
+      LIBRARY DESTINATION lib
+      RUNTIME DESTINATION bin
+    )
+  endif()
+
+  # install all executables
+  if(NOT ${PROJECT_NAME}_EXECUTABLES STREQUAL "")
+    if(_ARG_INSTALL_TO_PATH)
+      set(_destination "bin")
+    else()
+      set(_destination "lib/${PROJECT_NAME}")
+    endif()
+    install(
+      TARGETS ${${PROJECT_NAME}_EXECUTABLES}
+      DESTINATION ${_destination}
+    )
+  endif()
+
+  # install directories to share
+  foreach(_dir ${_ARG_INSTALL_TO_SHARE})
+    install(
+      DIRECTORY "${_dir}"
+      DESTINATION "share/${PROJECT_NAME}"
+    )
+  endforeach()
+
+  ament_execute_extensions(ament_auto_package)
+
+  ament_package(${_ARG_UNPARSED_ARGUMENTS})
+endmacro()

--- a/ament_cmake_auto/package.xml
+++ b/ament_cmake_auto/package.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="2">
+  <name>ament_cmake_auto</name>
+  <version>1.3.2</version>
+  <description>The auto-magic functions for ease to use of the ament buildsystem in CMake.</description>
+
+  <maintainer email="michael.jeronimo@openrobotics.org">Michael Jeronimo</maintainer>
+  <maintainer email="michel@ekumenlabs.com">Michel Hidalgo</maintainer>
+
+  <license>Apache License 2.0</license>
+
+  <author>Dirk Thomas</author>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_gtest</buildtool_depend>
+  <buildtool_export_depend>ament_cmake</buildtool_export_depend>
+  <buildtool_export_depend>ament_cmake_gtest</buildtool_export_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/autoware_cmake/cmake/autoware_package.cmake
+++ b/autoware_cmake/cmake/autoware_package.cmake
@@ -44,12 +44,6 @@ macro(autoware_package)
     add_compile_definitions(ROS_DISTRO_HUMBLE)
   endif()
 
-  # Set common system includes
-  find_package(Eigen3 REQUIRED)
-  include_directories(SYSTEM
-    ${EIGEN3_INCLUDE_DIR}
-  )
-
   # Find dependencies
   find_package(ament_cmake_auto REQUIRED)
   ament_auto_find_build_dependencies()

--- a/autoware_cmake/cmake/autoware_package.cmake
+++ b/autoware_cmake/cmake/autoware_package.cmake
@@ -44,6 +44,12 @@ macro(autoware_package)
     add_compile_definitions(ROS_DISTRO_HUMBLE)
   endif()
 
+  # Set common system includes
+  find_package(Eigen3 REQUIRED)
+  include_directories(SYSTEM
+    ${EIGEN3_INCLUDE_DIR}
+  )
+
   # Find dependencies
   find_package(ament_cmake_auto REQUIRED)
   ament_auto_find_build_dependencies()


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

I caught the following error in https://github.com/autowarefoundation/autoware/pull/330.

```
Starting >>> interpolation
[Processing: interpolation]
--- stderr: interpolation
In file included from /usr/include/eigen3/Eigen/Core:214,
                 from /autoware/install/tier4_autoware_utils/include/tier4_autoware_utils/geometry/boost_geometry.hpp:23,
                 from /autoware/install/tier4_autoware_utils/include/tier4_autoware_utils/geometry/geometry.hpp:23,
                 from /autoware/src/universe/autoware.universe/common/interpolation/include/interpolation/spline_interpolation.hpp:19,
                 from /autoware/src/universe/autoware.universe/common/interpolation/include/interpolation/spline_interpolation_points_2d.hpp:18,
                 from /autoware/src/universe/autoware.universe/common/interpolation/src/spline_interpolation_points_2d.cpp:15:
/usr/include/eigen3/Eigen/src/Core/arch/NEON/PacketMath.h: In function ‘Packet Eigen::internal::pload(const typename Eigen::internal::unpacket_traits<T>::type*) [with Packet = Eigen::internal::eigen_packet_wrapper<int, 2>; typename Eigen::internal::unpacket_traits<T>::type = signed char]’:
/usr/include/eigen3/Eigen/src/Core/arch/NEON/PacketMath.h:1671:9: error: ‘void* memcpy(void*, const void*, size_t)’ copying an object of non-trivial type ‘Eigen::internal::Packet4c’ {aka ‘struct Eigen::internal::eigen_packet_wrapper<int, 2>’} from an array of ‘const int8_t’ {aka ‘const signed char’} [-Werror=class-memaccess]
 1671 |   memcpy(&res, from, sizeof(Packet4c));
      |   ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This is the same reason as https://github.com/ANYbotics/grid_map/pull/349 and only happens with `arm64`.

Since we use `ament_cmake_auto`, I believe we can't apply the same solution for this until https://github.com/ament/ament_cmake/pull/385 is merged and released.

Therefore, I'd like to add common settings in `autoware_cmake`.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
