### PR TITLE
ci(sync-files): sync .clang-tidy

### DIFF
--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -19,6 +19,7 @@
     - source: .github/workflows/spell-check-differential.yaml
     - source: .github/workflows/sync-files.yaml
     - source: .clang-format
+    - source: .clang-tidy
     - source: .markdown-link-check.json
     - source: .markdownlint.yaml
     - source: .pre-commit-config-optional.yaml


### PR DESCRIPTION
Sync https://github.com/autowarefoundation/autoware/blob/main/.clang-tidy for local development.
Regarding CI, it's already used. https://github.com/autowarefoundation/autoware_common/blob/6bba407da4448c41d0e532b5f15d9cf262d5dff7/.github/workflows/build-and-test-differential.yaml#L88

Merge after https://github.com/autowarefoundation/autoware/pull/2763.