### PR TITLE
feat: add visualization for no detection area

### DIFF
--- a/tmp/lanelet2_extension/docs/lanelet2_format_extension.md
+++ b/tmp/lanelet2_extension/docs/lanelet2_format_extension.md
@@ -210,13 +210,16 @@ _An example:_
 ```
 
 ### No Obstacle Segmentation Area
+
 If there is a polygon area that has `no_obstacle_segmentation_area` tag, the obstacle points in this area are removed.
 If you want to ignore points for a certain module, you have to define another tag and specify it in the parameter of vector_map_inside_area_filter.
 Currently, following tags are defined other than `no_obstacle_segmentation_area`.
+
 - `no_obstacle_segmentation_area_for_run_out`
   - remove points for run out module
 
 _An example:_
+
 ```xml
   <way id="1658">
     <nd ref="1653"/>

--- a/tmp/lanelet2_extension/docs/lanelet2_format_extension.md
+++ b/tmp/lanelet2_extension/docs/lanelet2_format_extension.md
@@ -208,3 +208,22 @@ _An example:_
   <tag k='type' v='lanelet' />
 </relation>
 ```
+
+### No Obstacle Segmentation Area
+If there is a polygon area that has `no_obstacle_segmentation_area` tag, the obstacle points in this area are removed.
+If you want to ignore points for a certain module, you have to define another tag and specify it in the parameter of vector_map_inside_area_filter.
+Currently, following tags are defined other than `no_obstacle_segmentation_area`.
+- `no_obstacle_segmentation_area_for_run_out`
+  - remove points for run out module
+
+_An example:_
+```xml
+  <way id="1658">
+    <nd ref="1653"/>
+    <nd ref="1654"/>
+    <nd ref="1656"/>
+    <nd ref="1657"/>
+    <tag k="type" v="no_obstacle_segmentation_area"/>
+    <tag k="area" v="yes"/>
+  </way>
+```

--- a/tmp/lanelet2_extension/include/lanelet2_extension/utility/query.hpp
+++ b/tmp/lanelet2_extension/include/lanelet2_extension/utility/query.hpp
@@ -175,6 +175,9 @@ lanelet::ConstLineStrings3d getLinkedParkingSpaces(
 lanelet::ConstLanelets getLinkedLanelets(
   const lanelet::ConstPolygon3d & parking_lot, const lanelet::ConstLanelets & all_road_lanelets);
 
+// query all no detection area in lanelet2 map
+lanelet::ConstPolygons3d getAllNoDetectionArea(const lanelet::LaneletMapConstPtr & lanelet_map_ptr);
+
 /**
  * [stopLinesLanelets extracts stoplines that are associated to lanelets]
  * @param lanelets [input lanelets]

--- a/tmp/lanelet2_extension/include/lanelet2_extension/utility/query.hpp
+++ b/tmp/lanelet2_extension/include/lanelet2_extension/utility/query.hpp
@@ -114,8 +114,9 @@ std::vector<lanelet::DetectionAreaConstPtr> detectionAreas(const lanelet::ConstL
 std::vector<lanelet::NoStoppingAreaConstPtr> noStoppingAreas(
   const lanelet::ConstLanelets & lanelets);
 
-// query all no detection area in lanelet2 map
-lanelet::ConstPolygons3d getAllNoDetectionArea(const lanelet::LaneletMapConstPtr & lanelet_map_ptr);
+// query all polygons that has given type in lanelet2 map
+lanelet::ConstPolygons3d getAllPolygonsByType(
+  const lanelet::LaneletMapConstPtr & lanelet_map_ptr, const std::string & polygon_type);
 
 // query all obstacle polygons in lanelet2 map
 lanelet::ConstPolygons3d getAllObstaclePolygons(

--- a/tmp/lanelet2_extension/include/lanelet2_extension/utility/query.hpp
+++ b/tmp/lanelet2_extension/include/lanelet2_extension/utility/query.hpp
@@ -114,6 +114,9 @@ std::vector<lanelet::DetectionAreaConstPtr> detectionAreas(const lanelet::ConstL
 std::vector<lanelet::NoStoppingAreaConstPtr> noStoppingAreas(
   const lanelet::ConstLanelets & lanelets);
 
+// query all no detection area in lanelet2 map
+lanelet::ConstPolygons3d getAllNoDetectionArea(const lanelet::LaneletMapConstPtr & lanelet_map_ptr);
+
 // query all obstacle polygons in lanelet2 map
 lanelet::ConstPolygons3d getAllObstaclePolygons(
   const lanelet::LaneletMapConstPtr & lanelet_map_ptr);
@@ -174,9 +177,6 @@ lanelet::ConstLineStrings3d getLinkedParkingSpaces(
 // query linked lanelets from parking lot
 lanelet::ConstLanelets getLinkedLanelets(
   const lanelet::ConstPolygon3d & parking_lot, const lanelet::ConstLanelets & all_road_lanelets);
-
-// query all no detection area in lanelet2 map
-lanelet::ConstPolygons3d getAllNoDetectionArea(const lanelet::LaneletMapConstPtr & lanelet_map_ptr);
 
 /**
  * [stopLinesLanelets extracts stoplines that are associated to lanelets]

--- a/tmp/lanelet2_extension/include/lanelet2_extension/visualization/visualization.hpp
+++ b/tmp/lanelet2_extension/include/lanelet2_extension/visualization/visualization.hpp
@@ -270,6 +270,14 @@ visualization_msgs::msg::MarkerArray generateLaneletIdMarker(
 visualization_msgs::msg::MarkerArray obstaclePolygonsAsMarkerArray(
   const lanelet::ConstPolygons3d & obstacle_polygons, const std_msgs::msg::ColorRGBA & c);
 
+/**
+ * [NoDetectionAreaAsMarkerArray creates marker array to visualize no detection area]
+ * @param  no_detection_area [no detection area polygon]
+ * @param  c                 [color of the marker]
+ */
+visualization_msgs::msg::MarkerArray noDetectionAreaAsMarkerArray(
+  const lanelet::ConstPolygons3d & no_detection_area, const std_msgs::msg::ColorRGBA & c);
+
 }  // namespace lanelet::visualization
 
 // NOLINTEND(readability-identifier-naming)

--- a/tmp/lanelet2_extension/include/lanelet2_extension/visualization/visualization.hpp
+++ b/tmp/lanelet2_extension/include/lanelet2_extension/visualization/visualization.hpp
@@ -271,12 +271,25 @@ visualization_msgs::msg::MarkerArray obstaclePolygonsAsMarkerArray(
   const lanelet::ConstPolygons3d & obstacle_polygons, const std_msgs::msg::ColorRGBA & c);
 
 /**
- * [NoDetectionAreaAsMarkerArray creates marker array to visualize no detection area]
- * @param  no_detection_area [no detection area polygon]
- * @param  c                 [color of the marker]
+ * [noObstacleSegmentationAreaAsMarkerArray creates marker array to visualize no obstacle
+ * segmentation area]
+ * @param  no_obstacle_segmentation_area [no obstacle segmenatation area polygon]
+ * @param  c                             [color of the marker]
  */
-visualization_msgs::msg::MarkerArray noDetectionAreaAsMarkerArray(
-  const lanelet::ConstPolygons3d & no_detection_area, const std_msgs::msg::ColorRGBA & c);
+visualization_msgs::msg::MarkerArray noObstacleSegmentationAreaAsMarkerArray(
+  const lanelet::ConstPolygons3d & no_obstacle_segmentation_area,
+  const std_msgs::msg::ColorRGBA & c);
+
+/**
+ * [noObstacleSegmentationAreaForRunOutAsMarkerArray creates marker array to visualize no obstacle
+ * segmentation area for run out]
+ * @param  no_obstacle_segmentation_area_for_run_out [no obstacle segmentation area for run out
+ * polygon]
+ * @param  c                                         [color of the marker]
+ */
+visualization_msgs::msg::MarkerArray noObstacleSegmentationAreaForRunOutAsMarkerArray(
+  const lanelet::ConstPolygons3d & no_obstacle_segmentation_area_for_run_out,
+  const std_msgs::msg::ColorRGBA & c);
 
 }  // namespace lanelet::visualization
 

--- a/tmp/lanelet2_extension/include/lanelet2_extension/visualization/visualization.hpp
+++ b/tmp/lanelet2_extension/include/lanelet2_extension/visualization/visualization.hpp
@@ -273,7 +273,7 @@ visualization_msgs::msg::MarkerArray obstaclePolygonsAsMarkerArray(
 /**
  * [noObstacleSegmentationAreaAsMarkerArray creates marker array to visualize no obstacle
  * segmentation area]
- * @param  no_obstacle_segmentation_area [no obstacle segmenatation area polygon]
+ * @param  no_obstacle_segmentation_area [no obstacle segmentation area polygon]
  * @param  c                             [color of the marker]
  */
 visualization_msgs::msg::MarkerArray noObstacleSegmentationAreaAsMarkerArray(

--- a/tmp/lanelet2_extension/lib/query.cpp
+++ b/tmp/lanelet2_extension/lib/query.cpp
@@ -212,6 +212,19 @@ std::vector<lanelet::NoStoppingAreaConstPtr> query::noStoppingAreas(
   return no_reg_elems;
 }
 
+lanelet::ConstPolygons3d query::getAllNoDetectionArea(
+  const lanelet::LaneletMapConstPtr & lanelet_map_ptr)
+{
+  lanelet::ConstPolygons3d no_detection_area;
+  for (const auto & poly : lanelet_map_ptr->polygonLayer) {
+    const std::string type = poly.attributeOr(lanelet::AttributeName::Type, "none");
+    if (type == "no_detection_area") {
+      no_detection_area.push_back(poly);
+    }
+  }
+  return no_detection_area;
+}
+
 lanelet::ConstPolygons3d query::getAllObstaclePolygons(
   const lanelet::LaneletMapConstPtr & lanelet_map_ptr)
 {
@@ -878,20 +891,6 @@ std::vector<lanelet::ConstLanelets> query::getPrecedingLaneletSequences(
   }
   return lanelet_sequences_vec;
 }
-
-lanelet::ConstPolygons3d query::getAllNoDetectionArea(
-  const lanelet::LaneletMapConstPtr & lanelet_map_ptr)
-{
-  lanelet::ConstPolygons3d no_detection_area;
-  for (const auto & poly : lanelet_map_ptr->polygonLayer) {
-    const std::string type = poly.attributeOr(lanelet::AttributeName::Type, "none");
-    if (type == "no_detection_area") {
-      no_detection_area.push_back(poly);
-    }
-  }
-  return no_detection_area;
-}
-
 }  // namespace lanelet::utils
 
 // NOLINTEND(readability-identifier-naming)

--- a/tmp/lanelet2_extension/lib/query.cpp
+++ b/tmp/lanelet2_extension/lib/query.cpp
@@ -879,6 +879,19 @@ std::vector<lanelet::ConstLanelets> query::getPrecedingLaneletSequences(
   return lanelet_sequences_vec;
 }
 
+lanelet::ConstPolygons3d query::getAllNoDetectionArea(
+  const lanelet::LaneletMapConstPtr & lanelet_map_ptr)
+{
+  lanelet::ConstPolygons3d no_detection_area;
+  for (const auto & poly : lanelet_map_ptr->polygonLayer) {
+    const std::string type = poly.attributeOr(lanelet::AttributeName::Type, "none");
+    if (type.compare("no_detection_area") == 0) {
+      no_detection_area.push_back(poly);
+    }
+  }
+  return no_detection_area;
+}
+
 }  // namespace lanelet::utils
 
 // NOLINTEND(readability-identifier-naming)

--- a/tmp/lanelet2_extension/lib/query.cpp
+++ b/tmp/lanelet2_extension/lib/query.cpp
@@ -885,7 +885,7 @@ lanelet::ConstPolygons3d query::getAllNoDetectionArea(
   lanelet::ConstPolygons3d no_detection_area;
   for (const auto & poly : lanelet_map_ptr->polygonLayer) {
     const std::string type = poly.attributeOr(lanelet::AttributeName::Type, "none");
-    if (type.compare("no_detection_area") == 0) {
+    if (type == "no_detection_area") {
       no_detection_area.push_back(poly);
     }
   }

--- a/tmp/lanelet2_extension/lib/query.cpp
+++ b/tmp/lanelet2_extension/lib/query.cpp
@@ -212,17 +212,17 @@ std::vector<lanelet::NoStoppingAreaConstPtr> query::noStoppingAreas(
   return no_reg_elems;
 }
 
-lanelet::ConstPolygons3d query::getAllNoDetectionArea(
-  const lanelet::LaneletMapConstPtr & lanelet_map_ptr)
+lanelet::ConstPolygons3d query::getAllPolygonsByType(
+  const lanelet::LaneletMapConstPtr & lanelet_map_ptr, const std::string & polygon_type)
 {
-  lanelet::ConstPolygons3d no_detection_area;
+  lanelet::ConstPolygons3d polygons;
   for (const auto & poly : lanelet_map_ptr->polygonLayer) {
     const std::string type = poly.attributeOr(lanelet::AttributeName::Type, "none");
-    if (type == "no_detection_area") {
-      no_detection_area.push_back(poly);
+    if (type == polygon_type) {
+      polygons.push_back(poly);
     }
   }
-  return no_detection_area;
+  return polygons;
 }
 
 lanelet::ConstPolygons3d query::getAllObstaclePolygons(

--- a/tmp/lanelet2_extension/lib/visualization.cpp
+++ b/tmp/lanelet2_extension/lib/visualization.cpp
@@ -1263,6 +1263,25 @@ void visualization::pushArrowsMarker(
   }
 }
 
+visualization_msgs::msg::MarkerArray visualization::noDetectionAreaAsMarkerArray(
+  const lanelet::ConstPolygons3d & no_detection_area, const std_msgs::msg::ColorRGBA & c)
+{
+  visualization_msgs::msg::MarkerArray marker_array;
+  if (no_detection_area.empty()) {
+    return marker_array;
+  }
+
+  visualization_msgs::msg::Marker marker = createPolygonMarker("no_detection_area", c);
+  for (const auto & polygon : no_detection_area) {
+    pushPolygonMarker(&marker, polygon, c);
+  }
+
+  if (!marker.points.empty()) {
+    marker_array.markers.push_back(marker);
+  }
+  return marker_array;
+}
+
 }  // namespace lanelet
 
 // NOLINTEND(readability-identifier-naming)

--- a/tmp/lanelet2_extension/lib/visualization.cpp
+++ b/tmp/lanelet2_extension/lib/visualization.cpp
@@ -1263,16 +1263,39 @@ void visualization::pushArrowsMarker(
   }
 }
 
-visualization_msgs::msg::MarkerArray visualization::noDetectionAreaAsMarkerArray(
-  const lanelet::ConstPolygons3d & no_detection_area, const std_msgs::msg::ColorRGBA & c)
+visualization_msgs::msg::MarkerArray visualization::noObstacleSegmentationAreaAsMarkerArray(
+  const lanelet::ConstPolygons3d & no_obstacle_segmentation_area,
+  const std_msgs::msg::ColorRGBA & c)
 {
   visualization_msgs::msg::MarkerArray marker_array;
-  if (no_detection_area.empty()) {
+  if (no_obstacle_segmentation_area.empty()) {
     return marker_array;
   }
 
-  visualization_msgs::msg::Marker marker = createPolygonMarker("no_detection_area", c);
-  for (const auto & polygon : no_detection_area) {
+  visualization_msgs::msg::Marker marker = createPolygonMarker("no_obstacle_segmentation_area", c);
+  for (const auto & polygon : no_obstacle_segmentation_area) {
+    pushPolygonMarker(&marker, polygon, c);
+  }
+
+  if (!marker.points.empty()) {
+    marker_array.markers.push_back(marker);
+  }
+  return marker_array;
+}
+
+visualization_msgs::msg::MarkerArray
+visualization::noObstacleSegmentationAreaForRunOutAsMarkerArray(
+  const lanelet::ConstPolygons3d & no_obstacle_segmentation_area_for_run_out,
+  const std_msgs::msg::ColorRGBA & c)
+{
+  visualization_msgs::msg::MarkerArray marker_array;
+  if (no_obstacle_segmentation_area_for_run_out.empty()) {
+    return marker_array;
+  }
+
+  visualization_msgs::msg::Marker marker =
+    createPolygonMarker("no_obstacle_segmentation_area_for_run_out", c);
+  for (const auto & polygon : no_obstacle_segmentation_area_for_run_out) {
     pushPolygonMarker(&marker, polygon, c);
   }
 


### PR DESCRIPTION
Signed-off-by: Tomohito Ando <tomohito.ando@tier4.jp>

## Description

Added visualization for the polygon tagged as `no_detection_area`

Related PR:
- https://github.com/autowarefoundation/autoware.universe/pull/1530

![image](https://user-images.githubusercontent.com/11865769/186828014-83aa2210-e6a0-472b-ace6-4e38a8be0f6b.png)


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
