### PR TITLE
docs(lanelet2_extension): add crosswalk safety slow down annotation instructions

### DIFF
--- a/tmp/lanelet2_extension/docs/lanelet2_format_extension.md
+++ b/tmp/lanelet2_extension/docs/lanelet2_format_extension.md
@@ -197,6 +197,7 @@ the crosswalk definition on lanelet2 map:
   closest point to the crosswalk when ego vehicle slows down and drives at specified speed
 
 _An example:_
+
 ```xml
 <relation id='34378' visible='true' version='1'>
   <member type='way' ref='34374' role='left' />

--- a/tmp/lanelet2_extension/docs/lanelet2_format_extension.md
+++ b/tmp/lanelet2_extension/docs/lanelet2_format_extension.md
@@ -184,3 +184,26 @@ The following illustrates how light_bulbs are registered to traffic_light regula
   <member type='way' ref='11' role='light_bulbs'/> <!-- refers to the light_bulb line string -->
 </relation>
 ```
+
+### Safety Slow Down for Crosswalks
+
+If you wish ego vehicle to slow down to a certain speed from a certain distance while passing over a
+certain crosswalk _even though there are no target objects around it_, you can add following tags to
+the crosswalk definition on lanelet2 map:
+
+- `safety_slow_down_speed` **[m/s]**: The speed you want ego vehicle to drive at while passing over
+  the crosswalk
+- `safety_slow_down_distance` **[m]**: The distance between front bumper of ego vehicle and
+  closest point to the crosswalk when ego vehicle slows down and drives at specified speed
+
+_An example:_
+```xml
+<relation id='34378' visible='true' version='1'>
+  <member type='way' ref='34374' role='left' />
+  <member type='way' ref='34377' role='right' />
+  <tag k='subtype' v='crosswalk' />
+  <tag k='safety_slow_down_speed' v='3.0' />
+  <tag k='safety_slow_down_distance' v='2.0' />
+  <tag k='type' v='lanelet' />
+</relation>
+```


### PR DESCRIPTION
Signed-off-by: Mehmet Dogru <42mehmetdogru42@gmail.com>

## Description

Related to https://github.com/autowarefoundation/autoware.universe/pull/1528

This PR adds instructions to `lanelet2_extension` about safety slow down feature annotation for user-specified crosswalks

**!** This PR should be merged after https://github.com/autowarefoundation/autoware.universe/pull/1528 is merged **!**

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
