### PR TITLE
fix: traffic light visualization bug

### DIFF
--- a/tmp/lanelet2_extension/lib/visualization.cpp
+++ b/tmp/lanelet2_extension/lib/visualization.cpp
@@ -1100,7 +1100,7 @@ void visualization::pushTrafficLightTriangleMarker(
     marker->points.push_back(i);
     marker->colors.push_back(cl);
   }
-  for (const auto & i : tri0) {
+  for (const auto & i : tri1) {
     marker->points.push_back(i);
     marker->colors.push_back(cl);
   }


### PR DESCRIPTION
Signed-off-by: Yukihiro Saito <yukky.saito@gmail.com>

## Description
In https://github.com/autowarefoundation/autoware.universe/pull/1234, I think it is included same refactorings. Then, this bug maybe mixed.  



<!-- Write a brief description of this PR. -->
Before PR1234
- https://github.com/autowarefoundation/autoware.universe/pull/1234/files#diff-d8edbc2230e14e187bfe6c35f8d8dbb36ef71aed79c971d35d347f67643bfcc5

After
- https://github.com/autowarefoundation/autoware_common/commit/88d942752ca9f68d4f51120d1dba59648fef24ef#diff-c57401de2ce50215e6c07092f71d4f641f64d470bdb489b07a8079153599d2a8

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
