### PR TITLE
ci(check-build-depends): remove cancel workflow

### DIFF
--- a/.github/workflows/check-build-depends.yaml
+++ b/.github/workflows/check-build-depends.yaml
@@ -23,9 +23,6 @@ jobs:
             container: ros:humble
             build-depends-repos: build_depends.repos
     steps:
-      - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.10.0
-
       - name: Check out repository
         uses: actions/checkout@v3
 


### PR DESCRIPTION
Please refer to https://github.com/autowarefoundation/autoware.universe/pull/1736.