### PR TITLE
ci(check-build-depends): fix build-depends-repos

### DIFF
--- a/.github/workflows/check-build-depends.yaml
+++ b/.github/workflows/check-build-depends.yaml
@@ -38,4 +38,4 @@ jobs:
         with:
           rosdistro: ${{ matrix.rosdistro }}
           target-packages: ${{ steps.get-self-packages.outputs.self-packages }}
-          build-depends-repos: build_depends.repos
+          build-depends-repos: ${{ matrix.build-depends-repos }}


### PR DESCRIPTION
Fixup for https://github.com/autowarefoundation/autoware_common/pull/100.