### PR TITLE
ci: update minor CI settings

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,4 @@
 ### Copied from .github/CODEOWNERS-manual ###
-.github/* @autowarefoundation/autoware-maintainers
 
 ### Automatically generated from package.xml ###
 autoware_utils/* kenji.miyake@tier4.jp

--- a/.github/CODEOWNERS-manual
+++ b/.github/CODEOWNERS-manual
@@ -1,1 +1,0 @@
-.github/* @autowarefoundation/autoware-maintainers

--- a/.github/sync-files-reverse-reference.yaml
+++ b/.github/sync-files-reverse-reference.yaml
@@ -28,7 +28,6 @@
 
         sd "container: ghcr.io/autowarefoundation/autoware-universe:(\w+)-latest.*" "container: ros:\$1" {source}
         sd "build_depends.humble.repos" "build_depends.repos" {source}
-    - source: .github/workflows/cancel-previous-workflows.yaml
     - source: .github/workflows/check-build-depends.yaml
       pre-commands: |
         sd "container: ghcr.io/autowarefoundation/autoware-universe:(\w+)-latest.*" "container: ros:\$1" {source}

--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -12,6 +12,7 @@
     - source: .github/PULL_REQUEST_TEMPLATE/standard-change.md
     - source: .github/dependabot.yaml
     - source: .github/stale.yml
+    - source: .github/workflows/cancel-previous-workflows.yaml
     - source: .github/workflows/github-release.yaml
     - source: .github/workflows/pre-commit.yaml
     - source: .github/workflows/pre-commit-optional.yaml


### PR DESCRIPTION
Same as https://github.com/autowarefoundation/autoware.universe/pull/1765.
- Remove autoware-maintainers from `CODEOWNERS-manual`.
  - I've confirmed that `CODEOWNERS-manual` works.
  - It's noisy for other maintainers.
- Sync `cancel-previous-workflows.yaml` from autowarefoundation/autoware.
  - https://github.com/autowarefoundation/autoware/pull/2836