### PR TITLE
ci(build-and-test): add cmake-build-type

### DIFF
--- a/.github/workflows/build-and-test-self-hosted.yaml
+++ b/.github/workflows/build-and-test-self-hosted.yaml
@@ -15,6 +15,8 @@ jobs:
         rosdistro:
           - galactic
           - humble
+        cmake-build-type:
+          - Release
         include:
           - rosdistro: galactic
             container: ros:galactic
@@ -40,6 +42,7 @@ jobs:
           rosdistro: ${{ matrix.rosdistro }}
           target-packages: ${{ steps.get-self-packages.outputs.self-packages }}
           build-depends-repos: ${{ matrix.build-depends-repos }}
+          cmake-build-type: ${{ matrix.cmake-build-type }}
 
       - name: Test
         if: ${{ steps.get-self-packages.outputs.self-packages != '' }}

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -17,6 +17,8 @@ jobs:
         rosdistro:
           - galactic
           - humble
+        cmake-build-type:
+          - Release
         include:
           - rosdistro: galactic
             container: ros:galactic
@@ -42,6 +44,7 @@ jobs:
           rosdistro: ${{ matrix.rosdistro }}
           target-packages: ${{ steps.get-self-packages.outputs.self-packages }}
           build-depends-repos: ${{ matrix.build-depends-repos }}
+          cmake-build-type: ${{ matrix.cmake-build-type }}
 
       - name: Test
         if: ${{ steps.get-self-packages.outputs.self-packages != '' }}


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

Add an option for `CMAKE_BUILD_TYPE`.

Related:
- https://github.com/autowarefoundation/autoware.universe/pull/1965
- https://github.com/autowarefoundation/autoware-github-actions/pull/185

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
