### PR TITLE
AJD-568: Fix to processes dying randomly by introducing an autorespawning node container class

### DIFF
--- a/autoware_utils/CMakeLists.txt
+++ b/autoware_utils/CMakeLists.txt
@@ -2,11 +2,15 @@ cmake_minimum_required(VERSION 3.14)
 project(autoware_utils)
 
 find_package(autoware_cmake REQUIRED)
+find_package(ament_cmake_python REQUIRED)
+find_package(rclpy REQUIRED)
 autoware_package()
 
 ament_auto_add_library(autoware_utils SHARED
   src/autoware_utils.cpp
 )
+
+ament_python_install_package(${PROJECT_NAME})
 
 if(BUILD_TESTING)
   file(GLOB_RECURSE test_files test/**/*.cpp)

--- a/autoware_utils/autoware_utils/respawnable_node_container.py
+++ b/autoware_utils/autoware_utils/respawnable_node_container.py
@@ -1,0 +1,29 @@
+from launch_ros.actions import ComposableNodeContainer
+from launch_ros.descriptions import ComposableNode
+from typing import List
+from typing import Optional
+
+from launch.some_substitutions_type import SomeSubstitutionsType
+
+class RespawnableNodeContainer(ComposableNodeContainer):
+    """
+    Action that executes a container node for composable ROS nodes with fixed
+    respawn flag and time.
+    """
+
+    def __init__(
+        self,
+        *,
+        name: SomeSubstitutionsType,
+        namespace: SomeSubstitutionsType,
+        composable_node_descriptions: Optional[List[ComposableNode]] = None,
+        respawn = True,
+        respawn_delay = 0.5,
+        **kwargs
+    ) -> None:
+        super().__init__(
+            name=name,
+            namespace=namespace,
+            respawn=respawn,
+            respawn_delay=respawn_delay,
+            **kwargs)

--- a/autoware_utils/autoware_utils/respawnable_node_container.py
+++ b/autoware_utils/autoware_utils/respawnable_node_container.py
@@ -19,7 +19,7 @@ class RespawnableNodeContainer(ComposableNodeContainer):
         namespace: SomeSubstitutionsType,
         composable_node_descriptions: Optional[List[ComposableNode]] = None,
         respawn=True,
-        respawn_delay=0.5,
+        respawn_delay=0.05,
         **kwargs
     ) -> None:
         super().__init__(

--- a/autoware_utils/autoware_utils/respawnable_node_container.py
+++ b/autoware_utils/autoware_utils/respawnable_node_container.py
@@ -1,9 +1,10 @@
-from launch_ros.actions import ComposableNodeContainer
-from launch_ros.descriptions import ComposableNode
 from typing import List
 from typing import Optional
 
 from launch.some_substitutions_type import SomeSubstitutionsType
+from launch_ros.actions import ComposableNodeContainer
+from launch_ros.descriptions import ComposableNode
+
 
 class RespawnableNodeContainer(ComposableNodeContainer):
     """
@@ -17,8 +18,8 @@ class RespawnableNodeContainer(ComposableNodeContainer):
         name: SomeSubstitutionsType,
         namespace: SomeSubstitutionsType,
         composable_node_descriptions: Optional[List[ComposableNode]] = None,
-        respawn = True,
-        respawn_delay = 0.5,
+        respawn=True,
+        respawn_delay=0.5,
         **kwargs
     ) -> None:
         super().__init__(
@@ -27,5 +28,5 @@ class RespawnableNodeContainer(ComposableNodeContainer):
             composable_node_descriptions=composable_node_descriptions,
             respawn=respawn,
             respawn_delay=respawn_delay,
-            **kwargs)
-
+            **kwargs
+        )

--- a/autoware_utils/autoware_utils/respawnable_node_container.py
+++ b/autoware_utils/autoware_utils/respawnable_node_container.py
@@ -24,6 +24,8 @@ class RespawnableNodeContainer(ComposableNodeContainer):
         super().__init__(
             name=name,
             namespace=namespace,
+            composable_node_descriptions=composable_node_descriptions,
             respawn=respawn,
             respawn_delay=respawn_delay,
             **kwargs)
+

--- a/autoware_utils/package.xml
+++ b/autoware_utils/package.xml
@@ -8,11 +8,13 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <buildtool_depend>ament_cmake_python</buildtool_depend>
 
   <build_depend>autoware_cmake</build_depend>
 
   <depend>builtin_interfaces</depend>
   <depend>rclcpp</depend>
+  <depend>rclpy</depend>
 
   <test_depend>ament_cmake_ros</test_depend>
 


### PR DESCRIPTION
## Description

The idea here is to introduce a Python class that would be available for use across all the Autoware and take care of respawning processes that randomly happen to die due to not yet discovered reasons. The class is derived from the standard rospy `ComposableNodeContainer` and introduces two new default arguments: `respawn=True` and `repsawn_delay=0.5` (seconds). This ensures that a process that would die would subsequently be respawned and the error mentioned in [AJD-568](https://tier4.atlassian.net/browse/AJD-568) wouldn't occur.

## Related links

https://tier4.atlassian.net/browse/AJD-568

## Tests performed

For now, the PR was tested only locally using the scenario mentioned in the related ticket. The following node containers were changed to `RespawnableNodeContainers`: `autoware_iv_adaptor`, `awapi_relay_container`, `control_container`, `motion_velocity_smoother`, `behavior_planning_container`. Since the bug occurs randomly this would require additional testing before merging.

## Notes for reviewers

Introducing this fix would also require changing the above mentioned containers (and possibly others too) to RespawnableNodeContainer by casting PRs to their repositories.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
