### PR TITLE
ci(clang-tidy-pr-comments): add error handlings

### DIFF
--- a/.github/workflows/clang-tidy-pr-comments.yaml
+++ b/.github/workflows/clang-tidy-pr-comments.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   clang-tidy-pr-comments:
-    if: ${{ github.event.workflow_run.event == 'pull_request' }}
+    if: ${{ github.event.workflow_run.event == 'pull_request' && contains(fromJson('["success", "failure"]'), github.event.workflow_run.conclusion) }}
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository

--- a/.github/workflows/clang-tidy-pr-comments.yaml
+++ b/.github/workflows/clang-tidy-pr-comments.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   clang-tidy-pr-comments:
-    if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.event == 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
@@ -17,11 +17,18 @@ jobs:
 
       - name: Download analysis results
         run: |
-          gh run download ${{ github.event.workflow_run.id }} -D /tmp
+          gh run download ${{ github.event.workflow_run.id }} -D /tmp || true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Check if the fixes.yaml file exists
+        id: check-fixes-yaml-existence
+        uses: autowarefoundation/autoware-github-actions/check-file-existence@v1
+        with:
+          files: /tmp/clang-tidy-result/fixes.yaml
+
       - name: Set variables
+        if: ${{ steps.check-fixes-yaml-existence.outputs.exists == 'true' }}
         id: set-variables
         run: |
           echo ::set-output name=pr-id::"$(cat /tmp/clang-tidy-result/pr-id.txt)"
@@ -29,6 +36,7 @@ jobs:
           echo ::set-output name=pr-head-ref::"$(cat /tmp/clang-tidy-result/pr-head-ref.txt)"
 
       - name: Check out PR head
+        if: ${{ steps.check-fixes-yaml-existence.outputs.exists == 'true' }}
         uses: actions/checkout@v3
         with:
           repository: ${{ steps.set-variables.outputs.pr-head-repo }}
@@ -36,15 +44,18 @@ jobs:
           persist-credentials: false
 
       - name: Replace paths in fixes.yaml
+        if: ${{ steps.check-fixes-yaml-existence.outputs.exists == 'true' }}
         run: |
           sed -i -e "s|/__w/|/home/runner/work/|g" /tmp/clang-tidy-result/fixes.yaml
           cat /tmp/clang-tidy-result/fixes.yaml
 
       - name: Copy fixes.yaml to access from Docker Container Action
+        if: ${{ steps.check-fixes-yaml-existence.outputs.exists == 'true' }}
         run: |
           cp /tmp/clang-tidy-result/fixes.yaml fixes.yaml
 
       - name: Run clang-tidy-pr-comments action
+        if: ${{ steps.check-fixes-yaml-existence.outputs.exists == 'true' }}
         uses: platisd/clang-tidy-pr-comments@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

Currently, errors occur when:
- There is no `fixes.yaml`.
- There is no artifact.

https://github.com/autowarefoundation/autoware_common/runs/7642971961?check_suite_focus=true#step:7:1

```
Run sed -i -e "s|/__w/|/home/runner/work/|g" /tmp/clang-tidy-result/fixes.yaml
sed: can't read /tmp/clang-tidy-result/fixes.yaml: No such file or directory
Error: Process completed with exit code 2.
```

https://github.com/autowarefoundation/autoware_common/runs/8107985999?check_suite_focus=true

```
Run gh run download 2961696016 -D /tmp
no valid artifacts found to download
Error: Process completed with exit code 1.
```

To fix them, check the existence of `fixes.yaml`.

Also, for https://github.com/autowarefoundation/autoware-github-actions/pull/192, we need to also run the workflow when it's failed.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
