### PR TITLE
ci(clang-tidy-pr-comments): add the workflow_dispatch version

### DIFF
--- a/.github/workflows/clang-tidy-pr-comments-manually.yaml
+++ b/.github/workflows/clang-tidy-pr-comments-manually.yaml
@@ -1,0 +1,62 @@
+name: clang-tidy-pr-comments-manually
+
+on:
+  workflow_dispatch:
+    inputs:
+      workflow_run_id_or_url:
+        description: The target workflow run ID or URL of the build-and-test-differential workflow
+        required: true
+jobs:
+  clang-tidy-pr-comments:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Download analysis results
+        run: |
+          workflow_run_id=$(echo "${{ inputs.workflow_run_id_or_url }}" | sed -e "s|.*runs/||" -e "s|/jobs.*||")
+          gh run download "$workflow_run_id" -D /tmp || true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check if the fixes.yaml file exists
+        id: check-fixes-yaml-existence
+        uses: autowarefoundation/autoware-github-actions/check-file-existence@v1
+        with:
+          files: /tmp/clang-tidy-result/fixes.yaml
+
+      - name: Set variables
+        if: ${{ steps.check-fixes-yaml-existence.outputs.exists == 'true' }}
+        id: set-variables
+        run: |
+          echo ::set-output name=pr-id::"$(cat /tmp/clang-tidy-result/pr-id.txt)"
+          echo ::set-output name=pr-head-repo::"$(cat /tmp/clang-tidy-result/pr-head-repo.txt)"
+          echo ::set-output name=pr-head-ref::"$(cat /tmp/clang-tidy-result/pr-head-ref.txt)"
+
+      - name: Check out PR head
+        if: ${{ steps.check-fixes-yaml-existence.outputs.exists == 'true' }}
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ steps.set-variables.outputs.pr-head-repo }}
+          ref: ${{ steps.set-variables.outputs.pr-head-ref }}
+          persist-credentials: false
+
+      - name: Replace paths in fixes.yaml
+        if: ${{ steps.check-fixes-yaml-existence.outputs.exists == 'true' }}
+        run: |
+          sed -i -e "s|/__w/|/home/runner/work/|g" /tmp/clang-tidy-result/fixes.yaml
+          cat /tmp/clang-tidy-result/fixes.yaml
+
+      - name: Copy fixes.yaml to access from Docker Container Action
+        if: ${{ steps.check-fixes-yaml-existence.outputs.exists == 'true' }}
+        run: |
+          cp /tmp/clang-tidy-result/fixes.yaml fixes.yaml
+
+      - name: Run clang-tidy-pr-comments action
+        if: ${{ steps.check-fixes-yaml-existence.outputs.exists == 'true' }}
+        uses: platisd/clang-tidy-pr-comments@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          clang_tidy_fixes: fixes.yaml
+          pull_request_id: ${{ steps.set-variables.outputs.pr-id }}

--- a/.github/workflows/clang-tidy-pr-comments-manually.yaml
+++ b/.github/workflows/clang-tidy-pr-comments-manually.yaml
@@ -7,7 +7,7 @@ on:
         description: The target workflow run ID or URL of the build-and-test-differential workflow
         required: true
 jobs:
-  clang-tidy-pr-comments:
+  clang-tidy-pr-comments-manually:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

`clang-tidy-pr-comments` would be noisy if there are a lot of warnings.
In that case, it's useful if we can disable the normal `clang-tidy-pr-comments` workflow and manually run the workflow at whatever timing developers want.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
