### PR TITLE
refactor: applied clang-tidy

### DIFF
--- a/tmp/lanelet2_extension/src/check_right_of_way.cpp
+++ b/tmp/lanelet2_extension/src/check_right_of_way.cpp
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// NOLINTBEGIN(readability-identifier-naming)
-// NOLINTEND
-
 #include <lanelet2_extension/projection/mgrs_projector.hpp>
 #include <lanelet2_extension/utility/query.hpp>
 #include <lanelet2_extension/utility/utilities.hpp>
@@ -77,7 +74,7 @@ int main(int argc, char ** argv)
       yield_ids.insert(yield.id());
     }
 
-    std::set<int> conflicting_ids;
+    std::set<lanelet::Id> conflicting_ids;
     for (auto && right_of_way : right_of_ways) {
       const std::vector<lanelet::ConstLanelet> & conflicting_lanelets =
         lanelet::utils::getConflictingLanelets(routing_graph_ptr, right_of_way);

--- a/tmp/lanelet2_extension/src/check_right_of_way.cpp
+++ b/tmp/lanelet2_extension/src/check_right_of_way.cpp
@@ -37,14 +37,14 @@
 
 int main(int argc, char ** argv)
 {
-  // NOLINTBEGIN
   if (argc < 2) {
     std::cout << "usage: ros2 run lanelet2_extension check_right_of_way <map_path>";
     return 0;
   }
-  // NOLINTEND
 
+  // NOLINTBEGIN
   const std::string map_path = std::string(argv[1]);
+  // NOLINTEND
 
   lanelet::ErrorMessages errors{};
   lanelet::projection::MGRSProjector projector{};

--- a/tmp/lanelet2_extension/src/check_right_of_way.cpp
+++ b/tmp/lanelet2_extension/src/check_right_of_way.cpp
@@ -37,10 +37,12 @@
 
 int main(int argc, char ** argv)
 {
+  // NOLINTBEGIN
   if (argc < 2) {
     std::cout << "usage: ros2 run lanelet2_extension check_right_of_way <map_path>";
     return 0;
   }
+  // NOLINTEND
 
   const std::string map_path = std::string(argv[1]);
 

--- a/tmp/lanelet2_extension/src/check_right_of_way.cpp
+++ b/tmp/lanelet2_extension/src/check_right_of_way.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 // NOLINTBEGIN(readability-identifier-naming)
+// NOLINTEND
 
 #include <lanelet2_extension/projection/mgrs_projector.hpp>
 #include <lanelet2_extension/utility/query.hpp>
@@ -51,15 +52,15 @@ int main(int argc, char ** argv)
   lanelet::LaneletMapPtr map = lanelet::load(map_path, projector, &errors);
   for (auto && error : errors) std::cout << error << std::endl;
 
-  lanelet::traffic_rules::TrafficRulesPtr trafficRules =
+  lanelet::traffic_rules::TrafficRulesPtr traffic_rules =
     lanelet::traffic_rules::TrafficRulesFactory::create(
       lanelet::Locations::Germany, lanelet::Participants::Vehicle);
   lanelet::routing::RoutingGraphPtr routing_graph_ptr =
-    lanelet::routing::RoutingGraph::build(*map, *trafficRules);
+    lanelet::routing::RoutingGraph::build(*map, *traffic_rules);
 
   auto rows = map->regulatoryElementLayer  // filter elem whose Subtype is RightOfWay
               |
-              ranges::view::filter([](auto && elem) {
+              ranges::views::filter([](auto && elem) {
                 const auto & attrs = elem->attributes();
                 auto it = attrs.find(lanelet::AttributeName::Subtype);
                 return it != attrs.end() && it->second == lanelet::AttributeValueString::RightOfWay;
@@ -71,7 +72,7 @@ int main(int argc, char ** argv)
   for (auto && row : rows) {
     const auto & right_of_ways = row->rightOfWayLanelets();
     const auto & yields = row->yieldLanelets();
-    std::set<int> yield_ids;
+    std::set<lanelet::Id> yield_ids;
     for (auto && yield : yields) {
       yield_ids.insert(yield.id());
     }
@@ -83,11 +84,11 @@ int main(int argc, char ** argv)
       for (auto && conflict : conflicting_lanelets) conflicting_ids.insert(conflict.id());
     }
 
-    std::vector<int> unnecessary_yields;
+    std::vector<lanelet::Id> unnecessary_yields;
     set_difference(
       yield_ids.begin(), yield_ids.end(), conflicting_ids.begin(), conflicting_ids.end(),
       std::inserter(unnecessary_yields, unnecessary_yields.end()));
-    if (unnecessary_yields.size() == 0) continue;
+    if (unnecessary_yields.empty()) continue;
     std::cout << "RightOfWay " << row->id() << ": [";
     const char * delim = "";
     for (auto && unnecessary_yield : unnecessary_yields)


### PR DESCRIPTION
Signed-off-by: Mamoru Sobue <mamoru.sobue@tier4.jp>

## Description

I applied `clang-tidy` to the [prior PR](https://github.com/autowarefoundation/autoware_common/pull/114) and updated the code.

## Tests performed

I could not suppress this warning eventually, but I think this is C-specific matter.

```
 warning: do not use pointer arithmetic [cppcoreguidelines-pro-bounds-pointer-arithmetic]
  const std::string map_path = std::string(argv[1]);
```

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
