### PR TITLE
fix(lanelet2_extension): traffic light id marker array visualization

### DIFF
--- a/tmp/lanelet2_extension/lib/visualization.cpp
+++ b/tmp/lanelet2_extension/lib/visualization.cpp
@@ -515,7 +515,7 @@ visualization_msgs::msg::MarkerArray visualization::autowareTrafficLightsAsMarke
         visualization::pushTrafficLightTriangleMarker(&marker_tri, ls, c, scale);
       }
     }
-
+    marker_tri.id++;
     tl_marker_array.markers.push_back(marker_tri);
 
     lanelet::ConstLineStrings3d light_bulbs = tl->lightBulbs();
@@ -524,6 +524,7 @@ visualization_msgs::msg::MarkerArray visualization::autowareTrafficLightsAsMarke
       for (const auto & pt : l) {
         if (pt.hasAttribute("color")) {
           if (inputLightMarker(&marker_sph, pt)) {
+            marker_sph.id++;
             tl_marker_array.markers.push_back(marker_sph);
           }
         }


### PR DESCRIPTION
Signed-off-by: M. Fatih Cırıt <mfc@leodrive.ai>

## Description

OS: Ubuntu 22.04
ROS2: humble

Following the https://autowarefoundation.github.io/autoware-documentation/main/tutorials/ad-hoc-simulation/planning-simulation/ the lanelet map had the following error:
- `Multiple Markers in the same MarkerArray message had the same ns and id: (traffic_light_triangle, 0)`

![Screenshot from 2022-11-28 14-50-07](https://user-images.githubusercontent.com/10751153/204273791-0a393bfd-0224-48ca-a8e9-6ac52d1898e9.png)

**The reason for bug:**
- Multiple markers in the MarkerArray have the same ns and id
- It will only happen if your map has multiple traffic lights

**Solution:**
- For each marker pushed into the MarkerArray, increase the id by one.

**After this fix:**
![Screenshot from 2022-11-28 15-06-17](https://user-images.githubusercontent.com/10751153/204273801-5723c9bc-d7db-4e8f-b0fc-3fe9ebf3597a.png)


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
