### PR TITLE
Revert "build: add exec_depend on ros_environment"

### DIFF
--- a/autoware_cmake/package.xml
+++ b/autoware_cmake/package.xml
@@ -9,8 +9,6 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <exec_depend>ros_environment</exec_depend>
-
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
 


### PR DESCRIPTION
Reverts autowarefoundation/autoware_common#142

`autoware_cmake` is never run, so adding this dependency as an `exec_depends` doesn't make sense