### PR TITLE
feat(ros_version): add ros version testing

### DIFF
--- a/ros_version/CMakeLists.txt
+++ b/ros_version/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION 3.14)
+project(ros_version)
+
+### Compile options
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options()
+endif()
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
+ament_auto_add_library(ros_version SHARED
+  src/ros_version/ros_version.cpp
+)
+
+# Test
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+  find_package(ament_cmake_gtest REQUIRED)
+  file(GLOB_RECURSE test_files test/*.cpp)
+  ament_add_gtest(test_ros_version ${test_files})
+  target_link_libraries(test_ros_version
+    ros_version
+  )
+endif()
+ament_auto_package()

--- a/ros_version/include/ros_version/ros_version.hpp
+++ b/ros_version/include/ros_version/ros_version.hpp
@@ -11,3 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+#ifndef ROS_VERSION__ROS_VERSION_HPP_
+#define ROS_VERSION__ROS_VERSION_HPP_
+#endif  // ROS_VERSION__ROS_VERSION_HPP_

--- a/ros_version/include/ros_version/ros_version.hpp
+++ b/ros_version/include/ros_version/ros_version.hpp
@@ -1,0 +1,13 @@
+// Copyright 2023 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.

--- a/ros_version/package.xml
+++ b/ros_version/package.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>ros_version</name>
+  <version>0.1.0</version>
+  <maintainer email="taiki.tanaka@tier4.jp">tanaka3</maintainer>
+  <description>The gtest package</description>
+  <license>Apache License 2.0</license>
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <depend>rclcpp</depend>
+  <depend>std_srvs</depend>
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/ros_version/src/ros_version/ros_version.cpp
+++ b/ros_version/src/ros_version/ros_version.cpp
@@ -1,0 +1,15 @@
+// Copyright 2023 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+int main() { return 0; }

--- a/ros_version/test/test_ros_version.cpp
+++ b/ros_version/test/test_ros_version.cpp
@@ -1,0 +1,74 @@
+// Copyright 2023 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <rclcpp/rclcpp.hpp>
+#include <ros_version/ros_version.hpp>
+
+#include <std_srvs/srv/trigger.hpp>
+
+#include <gtest/gtest.h>
+#include <rclcpp/version.h>
+
+#include <chrono>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <string>
+
+using namespace std::chrono_literals;
+using std::placeholders::_1;
+using std::placeholders::_2;
+using std_srvs::srv::Trigger;
+
+class Minimal : public rclcpp::Node
+{
+public:
+  Minimal() : Node("minimal")
+  {
+// APIs taking rclcpp::QoS objects are only available in ROS 2 Iron and higher
+#if RCLCPP_VERSION_MAJOR >= 18
+    const auto qos = rclcpp::ServicesQoS();
+    std::cerr << "this version is not yet supported in current version" << std::cerr;
+#else
+    const auto qos = rmw_qos_profile_services_default;
+#endif
+    auto test_service =
+      create_service<Trigger>("/test_service", std::bind(&Minimal::testService, this, _1, _2), qos);
+    auto client_test = create_client<Trigger>("/test_service", qos);
+    auto req = std::make_shared<Trigger::Request>();
+    client_test->async_send_request(
+      req, [this]([[maybe_unused]] rclcpp::Client<Trigger>::SharedFuture result) {});
+  }
+
+  void testService(
+    [[maybe_unused]] const Trigger::Request::SharedPtr req,
+    [[maybe_unused]] const Trigger::Response::SharedPtr res)
+  {
+  }
+
+private:
+};
+
+TEST(test, nominal)
+{
+  rclcpp::init(0, nullptr);
+  rclcpp::spin_some(std::make_shared<Minimal>());
+  rclcpp::shutdown();
+}
+
+int main(int argc, char * argv[])
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/ros_version/test/test_ros_version.cpp
+++ b/ros_version/test/test_ros_version.cpp
@@ -26,13 +26,14 @@
 #include <memory>
 #include <string>
 
-using namespace std::chrono_literals;
 using std::placeholders::_1;
 using std::placeholders::_2;
 using std_srvs::srv::Trigger;
 
 class Minimal : public rclcpp::Node
 {
+  using std::chrono_literals;
+
 public:
   Minimal() : Node("minimal")
   {

--- a/ros_version/test/test_ros_version.cpp
+++ b/ros_version/test/test_ros_version.cpp
@@ -13,18 +13,15 @@
 // limitations under the License.
 
 #include <rclcpp/rclcpp.hpp>
-#include <ros_version/ros_version.hpp>
 
 #include <std_srvs/srv/trigger.hpp>
 
 #include <gtest/gtest.h>
 #include <rclcpp/version.h>
 
-#include <chrono>
 #include <functional>
 #include <iostream>
 #include <memory>
-#include <string>
 
 using std::placeholders::_1;
 using std::placeholders::_2;
@@ -32,8 +29,6 @@ using std_srvs::srv::Trigger;
 
 class Minimal : public rclcpp::Node
 {
-  using std::chrono_literals;
-
 public:
   Minimal() : Node("minimal")
   {


### PR DESCRIPTION
Signed-off-by: taikitanaka3 <taiki.tanaka@tier4.jp>

## Description

add autoware's ros version testing for future proof

```
1: [==========] Running 1 test from 1 test suite.
1: [----------] Global test environment set-up.
1: [----------] 1 test from test
1: [ RUN      ] test.nominal
1: [       OK ] test.nominal (206 ms)     
1: [----------] 1 test from test (206 ms total)
1: 
1: [----------] Global test environment tear-down
1: [==========] 1 test from 1 test suite ran. (206 ms total)
1: [  PASSED  ] 1 test.
1: -- run_test.py: return code 0
1: -- run_test.py: inject classname prefix into gtest result file 1/1 Test #1: test_ros_version .................   Passed    0.26 sec

100% tests passed, 0 tests failed out of 1

Label Time Summary:
gtest    =   0.26 sec*proc (1 test)

Total Test time (real) =   0.26 sec
Finished <<< ros_version [0.31s]          

Summary: 1 package finished [0.47s]
```

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
