### PR TITLE
docs(autoware_lint_common): add note in the readme

### DIFF
--- a/autoware_lint_common/README.md
+++ b/autoware_lint_common/README.md
@@ -22,11 +22,9 @@ if(BUILD_TESTING)
 endif()
 ```
 
-!!! note
+*For ROS 2 messages and services,*
 
-    **For ROS 2 messages,**
-    If there is `ADD_LINTER_TESTS` argument in the `rosidl_generate_interfaces()` function in the
-    `CMakelists.txt` file, you need to remove the `ADD_LINTER_TESTS` argument.
+If there is `ADD_LINTER_TESTS` argument in the `rosidl_generate_interfaces()` function in the `CMakelists.txt` file, you need to remove the `ADD_LINTER_TESTS` argument.
 
 Then, the following linters will run during `colcon test`.
 

--- a/autoware_lint_common/README.md
+++ b/autoware_lint_common/README.md
@@ -22,7 +22,7 @@ if(BUILD_TESTING)
 endif()
 ```
 
-*For ROS 2 messages and services,*
+_For ROS 2 messages and services,_
 
 If there is `ADD_LINTER_TESTS` argument in the `rosidl_generate_interfaces()` function in the `CMakelists.txt` file, you need to remove the `ADD_LINTER_TESTS` argument.
 

--- a/autoware_lint_common/README.md
+++ b/autoware_lint_common/README.md
@@ -24,6 +24,7 @@ endif()
 
 !!! note
 
+    **For ROS 2 messages,**
     If there is `ADD_LINTER_TESTS` argument in the `rosidl_generate_interfaces()` function in the
     `CMakelists.txt` file, you need to remove the `ADD_LINTER_TESTS` argument.
 

--- a/autoware_lint_common/README.md
+++ b/autoware_lint_common/README.md
@@ -24,9 +24,8 @@ endif()
 
 !!! note
 
-    If there is `ADD_LINTER_TESTS` argument in the `rosidl_generate_interfaces()` function in the 
+    If there is `ADD_LINTER_TESTS` argument in the `rosidl_generate_interfaces()` function in the
     `CMakelists.txt` file, you need to remove the `ADD_LINTER_TESTS` argument.
-
 
 Then, the following linters will run during `colcon test`.
 

--- a/autoware_lint_common/README.md
+++ b/autoware_lint_common/README.md
@@ -22,6 +22,12 @@ if(BUILD_TESTING)
 endif()
 ```
 
+!!! note
+
+    If there is `ADD_LINTER_TESTS` argument in the `rosidl_generate_interfaces()` function in the 
+    `CMakelists.txt` file, you need to remove the `ADD_LINTER_TESTS` argument.
+
+
 Then, the following linters will run during `colcon test`.
 
 - [ament_cmake_copyright](https://github.com/ament/ament_lint/blob/master/ament_cmake_copyright/doc/index.rst)

--- a/autoware_lint_common/README.md
+++ b/autoware_lint_common/README.md
@@ -22,9 +22,7 @@ if(BUILD_TESTING)
 endif()
 ```
 
-_For ROS 2 messages and services,_
-
-If there is `ADD_LINTER_TESTS` argument in the `rosidl_generate_interfaces()` function in the `CMakelists.txt` file, you need to remove the `ADD_LINTER_TESTS` argument.
+For ROS 2 messages and services, you need to remove the `ADD_LINTER_TESTS` argument in the `rosidl_generate_interfaces()` function in the `CMakelists.txt` file.
 
 Then, the following linters will run during `colcon test`.
 


### PR DESCRIPTION
Signed-off-by: M. Fatih Cırıt <mfc@leodrive.ai>

## Description

<!-- Write a brief description of this PR. -->
Follow up from https://github.com/autowarefoundation/autoware.core/issues/72#issuecomment-1415940370
`ADD_LINTER_TESTS` from `rosidl_generate_interfaces` adds unnecessary tests that are already covered by `pre-commit`.

This note will help developers avoid having similar problems like in the https://github.com/autowarefoundation/autoware.core/issues/72

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
