### PR TITLE
ci(pre-commit): disable autoupdate

### DIFF
--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -15,6 +15,7 @@
     - source: .github/workflows/cancel-previous-workflows.yaml
     - source: .github/workflows/github-release.yaml
     - source: .github/workflows/pre-commit.yaml
+    - source: .github/workflows/pre-commit-autoupdate.yaml
     - source: .github/workflows/pre-commit-optional.yaml
     - source: .github/workflows/semantic-pull-request.yaml
     - source: .github/workflows/spell-check-differential.yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,5 @@
 ci:
   autofix_commit_msg: "style(pre-commit): autofix"
-  autoupdate_commit_msg: "ci(pre-commit): autoupdate"
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
Use https://github.com/autowarefoundation/autoware/blob/main/.github/workflows/pre-commit-autoupdate.yaml instead. (Added the sync setting in https://github.com/autowarefoundation/autoware_common/pull/155/commits/4c43ef223e4b1098655fbcb392214a473b6bd686)

Related
- https://github.com/autowarefoundation/autoware.universe/pull/2838
- https://github.com/autowarefoundation/autoware/pull/3263
- https://github.com/autowarefoundation/autoware/pull/3264