### PR TITLE
perf(lanelet2_extension): improve performance of getClosestLanelet

### DIFF
--- a/tmp/lanelet2_extension/lib/query.cpp
+++ b/tmp/lanelet2_extension/lib/query.cpp
@@ -775,6 +775,11 @@ bool query::getClosestLanelet(
     }
   }
 
+  if(candidate_lanelets.size() == 1){
+    *closest_lanelet_ptr = candidate_lanelets.at(0);
+    return found;
+  }
+
   // find by angle
   {
     double min_angle = std::numeric_limits<double>::max();

--- a/tmp/lanelet2_extension/lib/query.cpp
+++ b/tmp/lanelet2_extension/lib/query.cpp
@@ -775,7 +775,7 @@ bool query::getClosestLanelet(
     }
   }
 
-  if(candidate_lanelets.size() == 1){
+  if (candidate_lanelets.size() == 1) {
     *closest_lanelet_ptr = candidate_lanelets.at(0);
     return found;
   }


### PR DESCRIPTION
Signed-off-by: Taiga Takano [taiga.takano@tier4.jp](mailto:taiga.takano@tier4.jp)

## Description

If the size of the candidate_lanelets is 1, the "Find by Angle" task can be skipped.

## Before and After
This change speeds up the process as shown in the table below.

getClosestLanelet callback latency
|  PERCENTILE  |  BEFORE (us)  |  AFTER (us)  |
| ---- | ---- | ---- |
|  99%  |  42.5  |  33.3  |
|  90%  |  28.6  |  21.4  |
|  50%  |  15.7  |  10.3  |