### PR TITLE
feat(lanelet2_extension): add lateral distance calculation functions

### DIFF
--- a/tmp/lanelet2_extension/include/lanelet2_extension/utility/utilities.hpp
+++ b/tmp/lanelet2_extension/include/lanelet2_extension/utility/utilities.hpp
@@ -111,7 +111,7 @@ bool isInLanelet(
   const double radius = 0.0);
 geometry_msgs::msg::Pose getClosestCenterPose(
   const lanelet::ConstLanelet & lanelet, const geometry_msgs::msg::Point & search_point);
-double getLateralDistanceToLanelet(
+double getLateralDistanceToCenterline(
   const lanelet::ConstLanelet & lanelet, const geometry_msgs::msg::Pose & pose);
 double getLateralDistanceToClosestLanelet(
   const lanelet::ConstLanelets & lanelet_sequence, const geometry_msgs::msg::Pose & pose);

--- a/tmp/lanelet2_extension/include/lanelet2_extension/utility/utilities.hpp
+++ b/tmp/lanelet2_extension/include/lanelet2_extension/utility/utilities.hpp
@@ -111,7 +111,9 @@ bool isInLanelet(
   const double radius = 0.0);
 geometry_msgs::msg::Pose getClosestCenterPose(
   const lanelet::ConstLanelet & lanelet, const geometry_msgs::msg::Point & search_point);
-
+double getLateralDistanceToLanelet(const lanelet::ConstLanelet & lanelet, const geometry_msgs::msg::Pose & pose);
+double getLateralDistanceToClosestLanelet(
+  const lanelet::ConstLanelets & lanelet_sequence, const geometry_msgs::msg::Pose & pose);
 }  // namespace lanelet::utils
 
 // NOLINTEND(readability-identifier-naming)

--- a/tmp/lanelet2_extension/include/lanelet2_extension/utility/utilities.hpp
+++ b/tmp/lanelet2_extension/include/lanelet2_extension/utility/utilities.hpp
@@ -111,7 +111,8 @@ bool isInLanelet(
   const double radius = 0.0);
 geometry_msgs::msg::Pose getClosestCenterPose(
   const lanelet::ConstLanelet & lanelet, const geometry_msgs::msg::Point & search_point);
-double getLateralDistanceToLanelet(const lanelet::ConstLanelet & lanelet, const geometry_msgs::msg::Pose & pose);
+double getLateralDistanceToLanelet(
+  const lanelet::ConstLanelet & lanelet, const geometry_msgs::msg::Pose & pose);
 double getLateralDistanceToClosestLanelet(
   const lanelet::ConstLanelets & lanelet_sequence, const geometry_msgs::msg::Pose & pose);
 }  // namespace lanelet::utils

--- a/tmp/lanelet2_extension/lib/utilities.cpp
+++ b/tmp/lanelet2_extension/lib/utilities.cpp
@@ -723,6 +723,22 @@ geometry_msgs::msg::Pose getClosestCenterPose(
 
   return closest_pose;
 }
+
+double getLateralDistanceToLanelet(const lanelet::ConstLanelet & lanelet, const geometry_msgs::msg::Pose & pose)
+{
+  const auto & centerline_2d = lanelet::utils::to2D(lanelet.centerline());
+  const auto lanelet_point = lanelet::utils::conversion::toLaneletPoint(pose.position);
+  return lanelet::geometry::signedDistance(
+    centerline_2d, lanelet::utils::to2D(lanelet_point).basicPoint());
+}
+
+double getLateralDistanceToClosestLanelet(
+  const lanelet::ConstLanelets & lanelet_sequence, const geometry_msgs::msg::Pose & pose)
+{
+  lanelet::ConstLanelet closest_lanelet;
+  lanelet::utils::query::getClosestLanelet(lanelet_sequence, pose, &closest_lanelet);
+  return getLateralDistanceToLanelet(closest_lanelet, pose);
+}
 }  // namespace lanelet::utils
 
 // NOLINTEND(readability-identifier-naming)

--- a/tmp/lanelet2_extension/lib/utilities.cpp
+++ b/tmp/lanelet2_extension/lib/utilities.cpp
@@ -724,7 +724,8 @@ geometry_msgs::msg::Pose getClosestCenterPose(
   return closest_pose;
 }
 
-double getLateralDistanceToLanelet(const lanelet::ConstLanelet & lanelet, const geometry_msgs::msg::Pose & pose)
+double getLateralDistanceToLanelet(
+  const lanelet::ConstLanelet & lanelet, const geometry_msgs::msg::Pose & pose)
 {
   const auto & centerline_2d = lanelet::utils::to2D(lanelet.centerline());
   const auto lanelet_point = lanelet::utils::conversion::toLaneletPoint(pose.position);

--- a/tmp/lanelet2_extension/lib/utilities.cpp
+++ b/tmp/lanelet2_extension/lib/utilities.cpp
@@ -738,7 +738,7 @@ double getLateralDistanceToClosestLanelet(
 {
   lanelet::ConstLanelet closest_lanelet;
   lanelet::utils::query::getClosestLanelet(lanelet_sequence, pose, &closest_lanelet);
-  return getLateralDistanceToLanelet(closest_lanelet, pose);
+  return getLateralDistanceToCenterline(closest_lanelet, pose);
 }
 }  // namespace lanelet::utils
 

--- a/tmp/lanelet2_extension/lib/utilities.cpp
+++ b/tmp/lanelet2_extension/lib/utilities.cpp
@@ -724,7 +724,7 @@ geometry_msgs::msg::Pose getClosestCenterPose(
   return closest_pose;
 }
 
-double getLateralDistanceToLanelet(
+double getLateralDistanceToCenterline(
   const lanelet::ConstLanelet & lanelet, const geometry_msgs::msg::Pose & pose)
 {
   const auto & centerline_2d = lanelet::utils::to2D(lanelet.centerline());


### PR DESCRIPTION
## Description
Add two functions that calculate the lateral distance to a designated lanelet or the closest lanelet.


## Related links
https://github.com/autowarefoundation/autoware.universe/blob/main/planning/behavior_path_planner/src/util/lane_change/util.cpp#L359
https://github.com/autowarefoundation/autoware.universe/blob/main/planning/behavior_path_planner/src/util/lane_change/util.cpp#L620
<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
