### PR TITLE
fix(lanelet2_extension): add exception handling for get closest segment

### DIFF
--- a/tmp/lanelet2_extension/lib/query.cpp
+++ b/tmp/lanelet2_extension/lib/query.cpp
@@ -786,12 +786,14 @@ bool query::getClosestLanelet(
     double pose_yaw = tf2::getYaw(search_pose.orientation);
     for (const auto & llt : candidate_lanelets) {
       lanelet::ConstLineString3d segment = getClosestSegment(search_point, llt.centerline());
+      double angle_diff = std::numeric_limits<double>::max();
       if (segment.empty()) {
-        continue;
+          angle_diff = M_PI;
+      } else {
+          double segment_angle = std::atan2(
+            segment.back().y() - segment.front().y(), segment.back().x() - segment.front().x());
+          angle_diff = std::abs(autoware_utils::normalize_radian(segment_angle - pose_yaw));
       }
-      double segment_angle = std::atan2(
-        segment.back().y() - segment.front().y(), segment.back().x() - segment.front().x());
-      double angle_diff = std::abs(autoware_utils::normalize_radian(segment_angle - pose_yaw));
       if (angle_diff < min_angle) {
         min_angle = angle_diff;
         *closest_lanelet_ptr = llt;

--- a/tmp/lanelet2_extension/lib/query.cpp
+++ b/tmp/lanelet2_extension/lib/query.cpp
@@ -786,6 +786,9 @@ bool query::getClosestLanelet(
     double pose_yaw = tf2::getYaw(search_pose.orientation);
     for (const auto & llt : candidate_lanelets) {
       lanelet::ConstLineString3d segment = getClosestSegment(search_point, llt.centerline());
+      if (segment.empty()) {
+        continue;
+      }
       double segment_angle = std::atan2(
         segment.back().y() - segment.front().y(), segment.back().x() - segment.front().x());
       double angle_diff = std::abs(autoware_utils::normalize_radian(segment_angle - pose_yaw));

--- a/tmp/lanelet2_extension/lib/query.cpp
+++ b/tmp/lanelet2_extension/lib/query.cpp
@@ -786,10 +786,8 @@ bool query::getClosestLanelet(
     double pose_yaw = tf2::getYaw(search_pose.orientation);
     for (const auto & llt : candidate_lanelets) {
       lanelet::ConstLineString3d segment = getClosestSegment(search_point, llt.centerline());
-      double angle_diff = std::numeric_limits<double>::max();
-      if (segment.empty()) {
-        angle_diff = M_PI;
-      } else {
+      double angle_diff = M_PI;
+      if (!segment.empty()) {
         double segment_angle = std::atan2(
           segment.back().y() - segment.front().y(), segment.back().x() - segment.front().x());
         angle_diff = std::abs(autoware_utils::normalize_radian(segment_angle - pose_yaw));

--- a/tmp/lanelet2_extension/lib/query.cpp
+++ b/tmp/lanelet2_extension/lib/query.cpp
@@ -788,11 +788,11 @@ bool query::getClosestLanelet(
       lanelet::ConstLineString3d segment = getClosestSegment(search_point, llt.centerline());
       double angle_diff = std::numeric_limits<double>::max();
       if (segment.empty()) {
-          angle_diff = M_PI;
+        angle_diff = M_PI;
       } else {
-          double segment_angle = std::atan2(
-            segment.back().y() - segment.front().y(), segment.back().x() - segment.front().x());
-          angle_diff = std::abs(autoware_utils::normalize_radian(segment_angle - pose_yaw));
+        double segment_angle = std::atan2(
+          segment.back().y() - segment.front().y(), segment.back().x() - segment.front().x());
+        angle_diff = std::abs(autoware_utils::normalize_radian(segment_angle - pose_yaw));
       }
       if (angle_diff < min_angle) {
         min_angle = angle_diff;

--- a/tmp/lanelet2_extension/lib/utilities.cpp
+++ b/tmp/lanelet2_extension/lib/utilities.cpp
@@ -716,8 +716,7 @@ geometry_msgs::msg::Pose getClosestCenterPose(
     return closest_pose;
   }
 
-  lanelet::ConstLineString3d segment =
-    getClosestSegment(llt_search_point, lanelet.centerline());
+  lanelet::ConstLineString3d segment = getClosestSegment(llt_search_point, lanelet.centerline());
   if (segment.empty()) {
     return geometry_msgs::msg::Pose{};
   }

--- a/tmp/lanelet2_extension/lib/utilities.cpp
+++ b/tmp/lanelet2_extension/lib/utilities.cpp
@@ -703,7 +703,24 @@ geometry_msgs::msg::Pose getClosestCenterPose(
   const lanelet::ConstLanelet & lanelet, const geometry_msgs::msg::Point & search_point)
 {
   lanelet::BasicPoint2d llt_search_point(search_point.x, search_point.y);
-  lanelet::ConstLineString3d segment = getClosestSegment(llt_search_point, lanelet.centerline());
+
+  if (lanelet.centerline().size() == 1) {
+    geometry_msgs::msg::Pose closest_pose;
+    closest_pose.position.x = lanelet.centerline().front().x();
+    closest_pose.position.y = lanelet.centerline().front().y();
+    closest_pose.position.z = search_point.z;
+    closest_pose.orientation.x = 0.0;
+    closest_pose.orientation.y = 0.0;
+    closest_pose.orientation.z = 0.0;
+    closest_pose.orientation.w = 1.0;
+    return closest_pose;
+  }
+
+  lanelet::ConstLineString3d segment =
+    getClosestSegment(llt_search_point, lanelet.centerline());
+  if (segment.empty()) {
+    return geometry_msgs::msg::Pose{};
+  }
 
   const Eigen::Vector2d direction(
     (segment.back().basicPoint2d() - segment.front().basicPoint2d()).normalized());


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

when segment is empty, accesing segment.back() causes node die.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

psim, tier4 internal scenario test

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
