### PR TITLE
feat: remove local x local y parser, move it to map_loader

### DIFF
--- a/tmp/lanelet2_extension/README.md
+++ b/tmp/lanelet2_extension/README.md
@@ -17,7 +17,6 @@ However, there are some custom tags that is used by the parser.
 
 Currently, this includes:
 
-- overwriting x,y values with `local_x` and `local_y` tags.
 - reading `<MapMetaInfo>` tag which contains information about map format version and map version.
 
 The parser is registered as "autoware_osm_handler" as lanelet parser

--- a/tmp/lanelet2_extension/docs/lanelet2_format_extension.md
+++ b/tmp/lanelet2_extension/docs/lanelet2_format_extension.md
@@ -118,7 +118,7 @@ Here is an example of MetaInfo in osm file:
 
 Sometimes users might want to create Lanelet2 maps that are not georeferenced.
 In such a case, users may use "local_x", "local_y" taggings to express local positions instead of latitude and longitude.
-Autoware Osm Parser will overwrite x,y positions with these tags when they are present.
+You will need to `lanelet2_map_projector_type` to `local`, then autoware map loader will overwrite x,y positions with these tags when they are present.
 For z values, use "ele" tags as default Lanelet2 Format.
 You would still need to fill in lat and lon attributes so that parser does not crush, but their values could be anything.
 

--- a/tmp/lanelet2_extension/docs/lanelet2_format_extension.md
+++ b/tmp/lanelet2_extension/docs/lanelet2_format_extension.md
@@ -118,7 +118,7 @@ Here is an example of MetaInfo in osm file:
 
 Sometimes users might want to create Lanelet2 maps that are not georeferenced.
 In such a case, users may use "local_x", "local_y" taggings to express local positions instead of latitude and longitude.
-You will need to `lanelet2_map_projector_type` to `local`, then autoware map loader will overwrite x,y positions with these tags when they are present.
+You will need to `lanelet2_map_projector_type` to `local`, then [autoware map loader](https://github.com/autowarefoundation/autoware.universe/tree/main/map/map_loader#lanelet2_map_loader) will overwrite x,y positions with these tags when they are present.
 For z values, use "ele" tags as default Lanelet2 Format.
 You would still need to fill in lat and lon attributes so that parser does not crush, but their values could be anything.
 

--- a/tmp/lanelet2_extension/lib/autoware_osm_parser.cpp
+++ b/tmp/lanelet2_extension/lib/autoware_osm_parser.cpp
@@ -33,16 +33,6 @@ std::unique_ptr<LaneletMap> AutowareOsmParser::parse(
 {
   auto map = OsmParser::parse(filename, errors);
 
-  // overwrite x and y values if there are local_x, local_y tags
-  for (Point3d point : map->pointLayer) {
-    if (point.hasAttribute("local_x")) {
-      point.x() = point.attribute("local_x").asDouble().value();
-    }
-    if (point.hasAttribute("local_y")) {
-      point.y() = point.attribute("local_y").asDouble().value();
-    }
-  }
-
   // rerun align function in just in case
   for (Lanelet & lanelet : map->laneletLayer) {
     LineString3d new_left;


### PR DESCRIPTION
## Description
- parser for local_x and local_y will be move to map_loader instead of loading in lanelet
https://github.com/autowarefoundation/autoware/issues/3427
https://github.com/autowarefoundation/autoware.universe/pull/3200
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
