### PR TITLE
build: mark autoware_cmake as <buildtool_depend>

### DIFF
--- a/autoware_utils/package.xml
+++ b/autoware_utils/package.xml
@@ -10,7 +10,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>builtin_interfaces</depend>
   <depend>rclcpp</depend>

--- a/tmp/lanelet2_extension/package.xml
+++ b/tmp/lanelet2_extension/package.xml
@@ -9,7 +9,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>autoware_cmake</build_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_mapping_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>


### PR DESCRIPTION
Since autoware_cmake only provide cmake macros only <buildtool_depend> is necessary. With <build_depend>, autoware_cmake is automatically exported with ament_target_dependencies() (unecessary)

## Description

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
