### PR TITLE
build: remove unused `<depend>` in package.xml files

### DIFF
--- a/autoware_utils/package.xml
+++ b/autoware_utils/package.xml
@@ -11,7 +11,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-  <depend>builtin_interfaces</depend>
   <depend>rclcpp</depend>
 
   <test_depend>ament_cmake_ros</test_depend>

--- a/tmp/lanelet2_extension/package.xml
+++ b/tmp/lanelet2_extension/package.xml
@@ -11,18 +11,14 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_mapping_msgs</depend>
-  <depend>autoware_auto_planning_msgs</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_utils</depend>
-  <depend>geographiclib</depend>
   <depend>geometry_msgs</depend>
   <depend>lanelet2_core</depend>
   <depend>lanelet2_io</depend>
-  <depend>lanelet2_maps</depend>
   <depend>lanelet2_projection</depend>
   <depend>lanelet2_routing</depend>
   <depend>lanelet2_traffic_rules</depend>
-  <depend>lanelet2_validation</depend>
   <depend>pugixml-dev</depend>
   <depend>range-v3</depend>
   <depend>rclcpp</depend>

--- a/tmp/lanelet2_extension/package.xml
+++ b/tmp/lanelet2_extension/package.xml
@@ -13,6 +13,7 @@
   <depend>autoware_auto_mapping_msgs</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_utils</depend>
+  <depend>geographiclib</depend>
   <depend>geometry_msgs</depend>
   <depend>lanelet2_core</depend>
   <depend>lanelet2_io</depend>


### PR DESCRIPTION
see https://github.com/autowarefoundation/autoware/issues/3468
To merge after all others package cleaning PR (to avoid missing deps downstream)

## Description

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
