### PR TITLE
feat: visualize hatched road markings

### DIFF
--- a/tmp/lanelet2_extension/include/lanelet2_extension/visualization/visualization.hpp
+++ b/tmp/lanelet2_extension/include/lanelet2_extension/visualization/visualization.hpp
@@ -305,10 +305,12 @@ visualization_msgs::msg::MarkerArray noObstacleSegmentationAreaForRunOutAsMarker
  * [hatchedRoadMarkingsAreaAsMarkerArray creates marker array to visualize hatched road markings
  * area]
  * @param  hatched_road_markings_area [hatched road markings area polygon]
- * @param  c                                         [color of the marker]
+ * @param  area_color                 [color of the area marker]
+ * @param  line_color                 [color of the line marker]
  */
 visualization_msgs::msg::MarkerArray hatchedRoadMarkingsAreaAsMarkerArray(
-  const lanelet::ConstPolygons3d & hatched_road_markings_area, const std_msgs::msg::ColorRGBA & c);
+  const lanelet::ConstPolygons3d & hatched_road_markings_area,
+  const std_msgs::msg::ColorRGBA & area_color, const std_msgs::msg::ColorRGBA & line_color);
 
 }  // namespace lanelet::visualization
 

--- a/tmp/lanelet2_extension/include/lanelet2_extension/visualization/visualization.hpp
+++ b/tmp/lanelet2_extension/include/lanelet2_extension/visualization/visualization.hpp
@@ -301,6 +301,15 @@ visualization_msgs::msg::MarkerArray noObstacleSegmentationAreaForRunOutAsMarker
   const lanelet::ConstPolygons3d & no_obstacle_segmentation_area_for_run_out,
   const std_msgs::msg::ColorRGBA & c);
 
+/**
+ * [hatchedRoadMarkingsAreaAsMarkerArray creates marker array to visualize hatched road markings
+ * area]
+ * @param  hatched_road_markings_area [hatched road markings area polygon]
+ * @param  c                                         [color of the marker]
+ */
+visualization_msgs::msg::MarkerArray hatchedRoadMarkingsAreaAsMarkerArray(
+  const lanelet::ConstPolygons3d & hatched_road_markings_area, const std_msgs::msg::ColorRGBA & c);
+
 }  // namespace lanelet::visualization
 
 // NOLINTEND(readability-identifier-naming)

--- a/tmp/lanelet2_extension/lib/visualization.cpp
+++ b/tmp/lanelet2_extension/lib/visualization.cpp
@@ -1394,7 +1394,7 @@ visualization_msgs::msg::MarkerArray visualization::hatchedRoadMarkingsAreaAsMar
   const float lss = 0.1;  // line string size
   visualization_msgs::msg::Marker line_strip;
   visualization::initLineStringMarker(
-    &line_strip, "map", "hatched_oard_markings_bound", line_color);
+    &line_strip, "map", "hatched_road_markings_bound", line_color);
 
   for (const auto & polygon : hatched_road_markings_area) {
     lanelet::LineString3d bound_ls(lanelet::utils::getId());

--- a/tmp/lanelet2_extension/lib/visualization.cpp
+++ b/tmp/lanelet2_extension/lib/visualization.cpp
@@ -1371,21 +1371,46 @@ visualization::noObstacleSegmentationAreaForRunOutAsMarkerArray(
 }
 
 visualization_msgs::msg::MarkerArray visualization::hatchedRoadMarkingsAreaAsMarkerArray(
-  const lanelet::ConstPolygons3d & hatched_road_markings_area, const std_msgs::msg::ColorRGBA & c)
+  const lanelet::ConstPolygons3d & hatched_road_markings_area,
+  const std_msgs::msg::ColorRGBA & area_color, const std_msgs::msg::ColorRGBA & line_color)
 {
   visualization_msgs::msg::MarkerArray marker_array;
   if (hatched_road_markings_area.empty()) {
     return marker_array;
   }
 
-  visualization_msgs::msg::Marker marker = createPolygonMarker("hatched_road_markings", c);
+  // polygon
+  visualization_msgs::msg::Marker area_marker =
+    createPolygonMarker("hatched_road_markings_area", area_color);
   for (const auto & polygon : hatched_road_markings_area) {
-    pushPolygonMarker(&marker, polygon, c);
+    pushPolygonMarker(&area_marker, polygon, area_color);
   }
 
-  if (!marker.points.empty()) {
-    marker_array.markers.push_back(marker);
+  if (!area_marker.points.empty()) {
+    marker_array.markers.push_back(area_marker);
   }
+
+  // line strings
+  const float lss = 0.1;  // line string size
+  visualization_msgs::msg::Marker line_strip;
+  visualization::initLineStringMarker(
+    &line_strip, "map", "hatched_oard_markings_bound", line_color);
+
+  for (const auto & polygon : hatched_road_markings_area) {
+    lanelet::LineString3d bound_ls(lanelet::utils::getId());
+    for (const auto & point : polygon) {
+      bound_ls.push_back(
+        lanelet::Point3d(lanelet::utils::getId(), point.x(), point.y(), point.z()));
+    }
+    if (!bound_ls.empty()) {
+      bound_ls.push_back(bound_ls.back());
+    }
+    visualization::pushLineStringMarker(&line_strip, bound_ls, line_color, lss);
+  }
+  if (!line_strip.points.empty()) {
+    marker_array.markers.push_back(line_strip);
+  }
+
   return marker_array;
 }
 }  // namespace lanelet

--- a/tmp/lanelet2_extension/lib/visualization.cpp
+++ b/tmp/lanelet2_extension/lib/visualization.cpp
@@ -1370,6 +1370,24 @@ visualization::noObstacleSegmentationAreaForRunOutAsMarkerArray(
   return marker_array;
 }
 
+visualization_msgs::msg::MarkerArray visualization::hatchedRoadMarkingsAreaAsMarkerArray(
+  const lanelet::ConstPolygons3d & hatched_road_markings_area, const std_msgs::msg::ColorRGBA & c)
+{
+  visualization_msgs::msg::MarkerArray marker_array;
+  if (hatched_road_markings_area.empty()) {
+    return marker_array;
+  }
+
+  visualization_msgs::msg::Marker marker = createPolygonMarker("hatched_road_markings", c);
+  for (const auto & polygon : hatched_road_markings_area) {
+    pushPolygonMarker(&marker, polygon, c);
+  }
+
+  if (!marker.points.empty()) {
+    marker_array.markers.push_back(marker);
+  }
+  return marker_array;
+}
 }  // namespace lanelet
 
 // NOLINTEND(readability-identifier-naming)


### PR DESCRIPTION
## Description

visualize hatched road markings area in LL2.
![image](https://user-images.githubusercontent.com/20228327/236818294-ae1de950-c731-4a9d-93c5-263829a699a1.png)

Discussion for introducing hatched road markings area.
https://github.com/orgs/autowarefoundation/discussions/3414
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

can visualize the area with planning simulator
## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
