### PR TITLE
fix(lanelet2_extension): fixed traffic_light marker id duplication

### DIFF
--- a/tmp/lanelet2_extension/lib/visualization.cpp
+++ b/tmp/lanelet2_extension/lib/visualization.cpp
@@ -105,14 +105,15 @@ void initLightMarker(visualization_msgs::msg::Marker * marker, const std::string
   marker->scale.z = s;
 }
 
-bool inputLightMarker(visualization_msgs::msg::Marker * marker, const lanelet::ConstPoint3d & p)
+bool inputLightMarker(
+  visualization_msgs::msg::Marker * marker, const lanelet::ConstPoint3d & p, const int & id)
 {
   if (marker == nullptr) {
     std::cerr << __FUNCTION__ << ": marker is null pointer!" << std::endl;
     return false;
   }
 
-  marker->id = static_cast<int32_t>(p.id());
+  marker->id = static_cast<int32_t>(id);
 
   geometry_msgs::msg::Point point;
   marker->pose.position.x = p.x();
@@ -523,7 +524,7 @@ visualization_msgs::msg::MarkerArray visualization::autowareTrafficLightsAsMarke
       lanelet::ConstLineString3d l = static_cast<lanelet::ConstLineString3d>(ls);
       for (const auto & pt : l) {
         if (pt.hasAttribute("color")) {
-          if (inputLightMarker(&marker_sph, pt)) {
+          if (inputLightMarker(&marker_sph, pt, marker_sph.id)) {
             marker_sph.id++;
             tl_marker_array.markers.push_back(marker_sph);
           }
@@ -541,6 +542,7 @@ visualization_msgs::msg::MarkerArray visualization::generateTrafficLightIdMaker(
 {
   visualization_msgs::msg::MarkerArray tl_id_marker_array;
 
+  int id = 0;
   for (const auto & tl : tl_reg_elems) {
     const auto lights = tl->trafficLights();
     for (const auto & lsp : lights) {
@@ -552,7 +554,7 @@ visualization_msgs::msg::MarkerArray visualization::generateTrafficLightIdMaker(
         marker.header.frame_id = "map";
         marker.header.stamp = rclcpp::Time();
         marker.ns = "traffic_light_id";
-        marker.id = static_cast<int32_t>(ls.id());
+        marker.id = static_cast<int32_t>(id++);
         marker.type = visualization_msgs::msg::Marker::TEXT_VIEW_FACING;
         marker.lifetime = duration;
         marker.action = visualization_msgs::msg::Marker::ADD;


### PR DESCRIPTION
## Description

Fixed the marker id duplication error of rviz visualization of traffic_light.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

### Before this PR

![image](https://github.com/autowarefoundation/autoware_common/assets/28677420/e542129d-0133-4f77-9332-088ccc152b97)

### After this PR

![image](https://github.com/autowarefoundation/autoware_common/assets/28677420/7c08daf2-b98f-4e29-8921-b729b2f10436)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
