### PR TITLE
build: fix build error with lanelet2 1.2.1

### DIFF
--- a/tmp/lanelet2_extension/CMakeLists.txt
+++ b/tmp/lanelet2_extension/CMakeLists.txt
@@ -48,6 +48,11 @@ ament_auto_add_library(lanelet2_extension_lib SHARED
 target_link_libraries(lanelet2_extension_lib
   ${GeographicLib_LIBRARIES}
 )
+get_target_property(lanelet2_core_INCLUDE_DIRECTORIES lanelet2_core::lanelet2_core INTERFACE_INCLUDE_DIRECTORIES)
+target_include_directories(lanelet2_extension_lib
+  SYSTEM PRIVATE
+    ${lanelet2_core_INCLUDE_DIRECTORIES}
+)
 
 ament_auto_add_executable(lanelet2_extension_sample src/sample_code.cpp)
 add_dependencies(lanelet2_extension_sample lanelet2_extension_lib)


### PR DESCRIPTION
## Description

mark lanelet2_core header as system due to the error below when it is built with lanelet2 1.2.1

```
In file included from /opt/ros/humble/include/lanelet2_core/geometry/LineString.h:295,
                 from /home/daisuke/workspace/pilot-auto.x2/src/autoware/common/tmp/lanelet2_extension/lib/autoware_osm_parser.cpp:21:
/opt/ros/humble/include/lanelet2_core/geometry/impl/LineString.h: In function ‘std::pair<double, lanelet::geometry::internal::ProjectedPointInfo<typename lanelet::traits::PointTraits<PointT>::BasicPoint> > lanelet::geometry::internal::signedDistanceImpl(LineStringT, const PointT&)’:
/opt/ros/humble/include/lanelet2_core/geometry/impl/LineString.h:130:9: error: typedef ‘using BasicPoint = PointT’ locally defined but not used [-Werror=unused-local-typedefs]
  130 |   using BasicPoint = PointT;
      |         ^~~~~~~~~~
In file included from /opt/ros/humble/include/lanelet2_core/geometry/LineString.h:295,
                 from /opt/ros/humble/include/lanelet2_core/geometry/Polygon.h:4,
                 from /opt/ros/humble/include/lanelet2_core/geometry/impl/Lanelet.h:10,
                 from /opt/ros/humble/include/lanelet2_core/geometry/Lanelet.h:195,
                 from /home/daisuke/workspace/pilot-auto.x2/src/autoware/common/tmp/lanelet2_extension/lib/query.cpp:27:
/opt/ros/humble/include/lanelet2_core/geometry/impl/LineString.h: In function ‘std::pair<double, lanelet::geometry::internal::ProjectedPointInfo<typename lanelet::traits::PointTraits<PointT>::BasicPoint> > lanelet::geometry::internal::signedDistanceImpl(LineStringT, const PointT&)’:
/opt/ros/humble/include/lanelet2_core/geometry/impl/LineString.h:130:9: error: typedef ‘using BasicPoint = PointT’ locally defined but not used [-Werror=unused-local-typedefs]
  130 |   using BasicPoint = PointT;
      |         ^~~~~~~~~~
In file included from /opt/ros/humble/include/lanelet2_core/geometry/LineString.h:295,
                 from /opt/ros/humble/include/lanelet2_core/geometry/Polygon.h:4,
                 from /opt/ros/humble/include/lanelet2_core/geometry/impl/Lanelet.h:10,
                 from /opt/ros/humble/include/lanelet2_core/geometry/Lanelet.h:195,
                 from /home/daisuke/workspace/pilot-auto.x2/src/autoware/common/tmp/lanelet2_extension/lib/utilities.cpp:24:
/opt/ros/humble/include/lanelet2_core/geometry/impl/LineString.h: In function ‘std::pair<double, lanelet::geometry::internal::ProjectedPointInfo<typename lanelet::traits::PointTraits<PointT>::BasicPoint> > lanelet::geometry::internal::signedDistanceImpl(LineStringT, const PointT&)’:
/opt/ros/humble/include/lanelet2_core/geometry/impl/LineString.h:130:9: error: typedef ‘using BasicPoint = PointT’ locally defined but not used [-Werror=unused-local-typedefs]
  130 |   using BasicPoint = PointT;
      |         ^~~~~~~~~~
cc1plus: all warnings being treated as errors
gmake[2]: *** [CMakeFiles/lanelet2_extension_lib.dir/build.make:76: CMakeFiles/lanelet2_extension_lib.dir/lib/autoware_osm_parser.cpp.o] Error 1
gmake[2]: *** Waiting for unfinished jobs....
cc1plus: all warnings being treated as errors
gmake[2]: *** [CMakeFiles/lanelet2_extension_lib.dir/build.make:202: CMakeFiles/lanelet2_extension_lib.dir/lib/utilities.cpp.o] Error 1
cc1plus: all warnings being treated as errors
gmake[2]: *** [CMakeFiles/lanelet2_extension_lib.dir/build.make:160: CMakeFiles/lanelet2_extension_lib.dir/lib/query.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:143: CMakeFiles/lanelet2_extension_lib.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
---
--- stderr: lanelet2_extension
In file included from /opt/ros/humble/include/lanelet2_core/geometry/LineString.h:295,
                 from /home/daisuke/workspace/pilot-auto.x2/src/autoware/common/tmp/lanelet2_extension/lib/autoware_osm_parser.cpp:21:
/opt/ros/humble/include/lanelet2_core/geometry/impl/LineString.h: In function ‘std::pair<double, lanelet::geometry::internal::ProjectedPointInfo<typename lanelet::traits::PointTraits<PointT>::BasicPoint> > lanelet::geometry::internal::signedDistanceImpl(LineStringT, const PointT&)’:
/opt/ros/humble/include/lanelet2_core/geometry/impl/LineString.h:130:9: error: typedef ‘using BasicPoint = PointT’ locally defined but not used [-Werror=unused-local-typedefs]
  130 |   using BasicPoint = PointT;
      |         ^~~~~~~~~~
In file included from /opt/ros/humble/include/lanelet2_core/geometry/LineString.h:295,
                 from /opt/ros/humble/include/lanelet2_core/geometry/Polygon.h:4,
                 from /opt/ros/humble/include/lanelet2_core/geometry/impl/Lanelet.h:10,
                 from /opt/ros/humble/include/lanelet2_core/geometry/Lanelet.h:195,
                 from /home/daisuke/workspace/pilot-auto.x2/src/autoware/common/tmp/lanelet2_extension/lib/query.cpp:27:
/opt/ros/humble/include/lanelet2_core/geometry/impl/LineString.h: In function ‘std::pair<double, lanelet::geometry::internal::ProjectedPointInfo<typename lanelet::traits::PointTraits<PointT>::BasicPoint> > lanelet::geometry::internal::signedDistanceImpl(LineStringT, const PointT&)’:
/opt/ros/humble/include/lanelet2_core/geometry/impl/LineString.h:130:9: error: typedef ‘using BasicPoint = PointT’ locally defined but not used [-Werror=unused-local-typedefs]
  130 |   using BasicPoint = PointT;
      |         ^~~~~~~~~~
In file included from /opt/ros/humble/include/lanelet2_core/geometry/LineString.h:295,
                 from /opt/ros/humble/include/lanelet2_core/geometry/Polygon.h:4,
                 from /opt/ros/humble/include/lanelet2_core/geometry/impl/Lanelet.h:10,
                 from /opt/ros/humble/include/lanelet2_core/geometry/Lanelet.h:195,
                 from /home/daisuke/workspace/pilot-auto.x2/src/autoware/common/tmp/lanelet2_extension/lib/utilities.cpp:24:
/opt/ros/humble/include/lanelet2_core/geometry/impl/LineString.h: In function ‘std::pair<double, lanelet::geometry::internal::ProjectedPointInfo<typename lanelet::traits::PointTraits<PointT>::BasicPoint> > lanelet::geometry::internal::signedDistanceImpl(LineStringT, const PointT&)’:
/opt/ros/humble/include/lanelet2_core/geometry/impl/LineString.h:130:9: error: typedef ‘using BasicPoint = PointT’ locally defined but not used [-Werror=unused-local-typedefs]
  130 |   using BasicPoint = PointT;
      |         ^~~~~~~~~~
cc1plus: all warnings being treated as errors
gmake[2]: *** [CMakeFiles/lanelet2_extension_lib.dir/build.make:76: CMakeFiles/lanelet2_extension_lib.dir/lib/autoware_osm_parser.cpp.o] Error 1
gmake[2]: *** Waiting for unfinished jobs....
cc1plus: all warnings being treated as errors
gmake[2]: *** [CMakeFiles/lanelet2_extension_lib.dir/build.make:202: CMakeFiles/lanelet2_extension_lib.dir/lib/utilities.cpp.o] Error 1
cc1plus: all warnings being treated as errors
gmake[2]: *** [CMakeFiles/lanelet2_extension_lib.dir/build.make:160: CMakeFiles/lanelet2_extension_lib.dir/lib/query.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:143: CMakeFiles/lanelet2_extension_lib.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
---
Failed   <<< lanelet2_extension [32.5s, exited with code 2]
```

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
