### PR TITLE
fix(build): additional fix for build error in test

### DIFF
--- a/tmp/lanelet2_extension/CMakeLists.txt
+++ b/tmp/lanelet2_extension/CMakeLists.txt
@@ -88,6 +88,10 @@ if(BUILD_TESTING)
   target_link_libraries(regulatory_elements-test lanelet2_extension_lib)
   ament_add_ros_isolated_gtest(utilities-test test/src/test_utilities.cpp)
   target_link_libraries(utilities-test lanelet2_extension_lib)
+  target_include_directories(utilities-test
+  SYSTEM PRIVATE
+    ${lanelet2_core_INCLUDE_DIRECTORIES}
+  )
   ament_add_ros_isolated_gtest(route-test test/src/test_route_checker.cpp)
   target_link_libraries(route-test lanelet2_extension_lib)
 endif()


### PR DESCRIPTION
## Description

Fixed build error happened on my environment:

Ubuntu: 22.04
kernel: 5.14.0-1054-oem
cmake: 3.26.3
g++ 11.3.0
ros-humble-lanelet2-core: 1.2.1-1jammy.20230511.171418

## Related links

#183 

## Tests performed

compiles on my machine as well

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
