### PR TITLE
fix: visualize hatched road markings

### DIFF
--- a/tmp/lanelet2_extension/lib/visualization.cpp
+++ b/tmp/lanelet2_extension/lib/visualization.cpp
@@ -1465,7 +1465,7 @@ visualization_msgs::msg::MarkerArray visualization::hatchedRoadMarkingsAreaAsMar
         lanelet::Point3d(lanelet::utils::getId(), point.x(), point.y(), point.z()));
     }
     if (!bound_ls.empty()) {
-      bound_ls.push_back(bound_ls.back());
+      bound_ls.push_back(bound_ls.front());
     }
     visualization::pushLineStringMarker(&line_strip, bound_ls, line_color, lss);
   }


### PR DESCRIPTION
## Description

Hatched road markings are visualized incorrectly without this PR. The boundary is not connected.

**Without this PR**
The bottom left object is hatched road markings, whose boundary is not fully connected.
![image](https://github.com/autowarefoundation/autoware_common/assets/20228327/638889e5-3066-440d-9de2-3f968136fab7)

**With this PR**
![image](https://github.com/autowarefoundation/autoware_common/assets/20228327/96b29373-c58f-4737-b69a-3525cd00460a)

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

planning simulator

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
