### PR TITLE
feat(autoware_cmake): add workaround for lanelet2@1.2.1

### DIFF
--- a/autoware_cmake/cmake/autoware_package.cmake
+++ b/autoware_cmake/cmake/autoware_package.cmake
@@ -53,6 +53,14 @@ macro(autoware_package)
     ${EIGEN3_INCLUDE_DIR}
   )
 
+  # Workaround for lanelet2-core@1.2.1
+  if(TARGET lanelet2_core::lanelet2_core)
+    get_target_property(lanelet2_core_INCLUDE_DIRECTORIES lanelet2_core::lanelet2_core INTERFACE_INCLUDE_DIRECTORIES)
+    include_directories(SYSTEM
+      ${lanelet2_core_INCLUDE_DIRECTORIES}
+    )
+  endif()
+
   # Find test dependencies
   if(BUILD_TESTING)
     find_package(ament_lint_auto REQUIRED)


### PR DESCRIPTION
## Description

`autoware_cmake` needs to be fixed for compiling old version of autoware due to the update of lanelet2-core.

cc @tkimura4 @shmpwk 

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

Beta branch of https://github.com/tier4/autoware.universe can be compiled.

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
