### PR TITLE
ci(build-and-test): fix free disk space error

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -28,6 +28,8 @@ jobs:
         uses: jlumbroso/free-disk-space@v1.2.0
         with:
           tool-cache: false
+          dotnet: false
+          large-packages: false
 
       - name: Remove exec_depend
         uses: autowarefoundation/autoware-github-actions/remove-exec-depend@v1

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -29,6 +29,7 @@ jobs:
         with:
           tool-cache: false
           dotnet: false
+          swap-storage: false
           large-packages: false
 
       - name: Remove exec_depend


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
https://github.com/autowarefoundation/autoware_common/pull/197 causes the error because the CI cannot find `dotnet-*`.
https://github.com/autowarefoundation/autoware_common/actions/runs/5497109614/jobs/10017557487

To avoid this, this PR ignores installing `dotnet-*`.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

CI passed at free disk space
https://github.com/autowarefoundation/autoware_common/actions/runs/5502951274/jobs/10027671593

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Only build effect

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
