### PR TITLE
chore(lanelet2_extension): remove unnecessary print

### DIFF
--- a/tmp/lanelet2_extension/lib/query.cpp
+++ b/tmp/lanelet2_extension/lib/query.cpp
@@ -896,7 +896,6 @@ bool query::getClosestLaneletWithConstrains(
           const std::pair<lanelet::ConstLanelet, double> & x,
           std::pair<lanelet::ConstLanelet, double> & y) { return x.second < y.second; });
     } else {
-      std::cerr << "there are no lanelets close enough!" << std::endl;
       return found;
     }
   }


### PR DESCRIPTION
## Description

With the change, before setting an ego pose, "there are no lanelets close enough!" is printed a lot. Printing this every cycle seems not necessary which cannot be controlled by the application (node) side.
https://github.com/autowarefoundation/autoware.universe/pull/4941
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

planning simulator

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
