### PR TITLE
feat(lanelet2_extensions): add query curbstones from vector map

### DIFF
--- a/tmp/lanelet2_extension/include/lanelet2_extension/utility/query.hpp
+++ b/tmp/lanelet2_extension/include/lanelet2_extension/utility/query.hpp
@@ -129,6 +129,9 @@ std::vector<lanelet::SpeedBumpConstPtr> speedBumps(const lanelet::ConstLanelets 
  */
 std::vector<lanelet::CrosswalkConstPtr> crosswalks(const lanelet::ConstLanelets & lanelets);
 
+// query all curbstones in lanelet2 map
+lanelet::ConstLineStrings3d curbstones(const lanelet::LaneletMapConstPtr & lanelet_map_ptr);
+
 // query all polygons that has given type in lanelet2 map
 lanelet::ConstPolygons3d getAllPolygonsByType(
   const lanelet::LaneletMapConstPtr & lanelet_map_ptr, const std::string & polygon_type);

--- a/tmp/lanelet2_extension/lib/query.cpp
+++ b/tmp/lanelet2_extension/lib/query.cpp
@@ -305,6 +305,19 @@ std::vector<lanelet::CrosswalkConstPtr> query::crosswalks(const lanelet::ConstLa
   return cw_reg_elems;
 }
 
+lanelet::ConstLineStrings3d query::curbstones(
+  const lanelet::LaneletMapConstPtr & lanelet_map_ptr)
+{
+  lanelet::ConstLineStrings3d curbstones;
+  for (const auto & ls : lanelet_map_ptr->lineStringLayer) {
+    const std::string type = ls.attributeOr(lanelet::AttributeName::Type, "none");
+    if (type == "curbstone") {
+      curbstones.push_back(ls);
+    }
+  }
+  return curbstones;
+}
+
 lanelet::ConstPolygons3d query::getAllPolygonsByType(
   const lanelet::LaneletMapConstPtr & lanelet_map_ptr, const std::string & polygon_type)
 {

--- a/tmp/lanelet2_extension/lib/query.cpp
+++ b/tmp/lanelet2_extension/lib/query.cpp
@@ -305,8 +305,7 @@ std::vector<lanelet::CrosswalkConstPtr> query::crosswalks(const lanelet::ConstLa
   return cw_reg_elems;
 }
 
-lanelet::ConstLineStrings3d query::curbstones(
-  const lanelet::LaneletMapConstPtr & lanelet_map_ptr)
+lanelet::ConstLineStrings3d query::curbstones(const lanelet::LaneletMapConstPtr & lanelet_map_ptr)
 {
   lanelet::ConstLineStrings3d curbstones;
   for (const auto & ls : lanelet_map_ptr->lineStringLayer) {


### PR DESCRIPTION
## Description

This PR makes enable to query curbstones from vector map.
The purpose of this feature is to publish curbstones as MarkerArray.

The background of this PR is below.
If the vector map contains a curbstone, we would like to check the position of the curbstone on rviz.
Because we need to know how much clearance do we have. 
I propose adding a marker array of curbstone.
https://github.com/autowarefoundation/autoware.universe/pull/4958
![Screenshot from 2023-09-11 19-29-01](https://github.com/autowarefoundation/autoware_common/assets/19224532/a1d24693-3df1-44b9-a17e-09f78ec5fa48)

## Tests performed

PSim

## Effects on system behavior

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
