### PR TITLE
fix(lanelet2_extensions): fix traffic_light visualization marker id duplication

### DIFF
--- a/tmp/lanelet2_extension/lib/visualization.cpp
+++ b/tmp/lanelet2_extension/lib/visualization.cpp
@@ -112,8 +112,6 @@ bool inputLightMarker(visualization_msgs::msg::Marker * marker, const lanelet::C
     return false;
   }
 
-  marker->id = static_cast<int32_t>(p.id());
-
   geometry_msgs::msg::Point point;
   marker->pose.position.x = p.x();
   marker->pose.position.y = p.y();
@@ -540,6 +538,7 @@ visualization_msgs::msg::MarkerArray visualization::generateTrafficLightIdMaker(
   const std_msgs::msg::ColorRGBA & c, const rclcpp::Duration & duration, const double scale)
 {
   visualization_msgs::msg::MarkerArray tl_id_marker_array;
+  int32_t marker_id = 0;
 
   for (const auto & tl : tl_reg_elems) {
     const auto lights = tl->trafficLights();
@@ -552,7 +551,7 @@ visualization_msgs::msg::MarkerArray visualization::generateTrafficLightIdMaker(
         marker.header.frame_id = "map";
         marker.header.stamp = rclcpp::Time();
         marker.ns = "traffic_light_id";
-        marker.id = static_cast<int32_t>(ls.id());
+        marker.id = marker_id++;
         marker.type = visualization_msgs::msg::Marker::TEXT_VIEW_FACING;
         marker.lifetime = duration;
         marker.action = visualization_msgs::msg::Marker::ADD;


### PR DESCRIPTION
## Description
This PR resolves duplicate IDs in the visualization_marker of the traffic light.

Related issue: https://github.com/orgs/autowarefoundation/discussions/3825
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
