### PR TITLE
fix(visualization): display traffic reg elem id

### DIFF
--- a/tmp/lanelet2_extension/lib/visualization.cpp
+++ b/tmp/lanelet2_extension/lib/visualization.cpp
@@ -569,7 +569,7 @@ visualization_msgs::msg::MarkerArray visualization::generateTrafficLightIdMaker(
         marker.color = c;
         marker.scale.z = scale;
         marker.frame_locked = false;
-        marker.text = std::to_string(ls.id());
+        marker.text = std::to_string(tl->id());
         tl_id_marker_array.markers.push_back(marker);
       }
     }


### PR DESCRIPTION
## Description

Display the id of traffic light regulatory  element id

![image](https://github.com/autowarefoundation/autoware_common/assets/28677420/3beacc4b-6336-4c26-bc5a-8faaac760a46)

## Tests performed

none.

## Effects on system behavior

none.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
