### PR TITLE
feat(lanelet2_extension): added localization landmark

### DIFF
--- a/tmp/lanelet2_extension/CMakeLists.txt
+++ b/tmp/lanelet2_extension/CMakeLists.txt
@@ -35,6 +35,7 @@ ament_auto_add_library(lanelet2_extension_lib SHARED
   lib/autoware_traffic_light.cpp
   lib/crosswalk.cpp
   lib/detection_area.cpp
+  lib/landmark.cpp
   lib/no_parking_area.cpp
   lib/no_stopping_area.cpp
   lib/message_conversion.cpp

--- a/tmp/lanelet2_extension/docs/lanelet2_format_extension.md
+++ b/tmp/lanelet2_extension/docs/lanelet2_format_extension.md
@@ -417,6 +417,8 @@ Landmarks, such as AR-Tags, can be defined into the lanelet map to aid localizat
 
 Landmark Specifications:
 
+<!-- cspell:ignore apiltag -->
+
 - **Shape**: Landmarks must be flat and defined as a polygon with exactly four vertices.
 - **Vertex Definition**: Vertices must be defined in a counter-clockwise order.
 - **Coordinate System** and Vertex Order:

--- a/tmp/lanelet2_extension/docs/lanelet2_format_extension.md
+++ b/tmp/lanelet2_extension/docs/lanelet2_format_extension.md
@@ -410,3 +410,70 @@ _An example:_
 ```
 
 For more details about the `no_drivable_lane` concept and design, please refer to the [**_no-drivable-lane-design_**](https://github.com/autowarefoundation/autoware.universe/blob/main/planning/behavior_velocity_no_drivable_lane_module/README.md) document.
+
+### Localization Landmarks
+
+Landmarks, such as AR-Tags, can be defined into the lanelet map to aid localization module.
+
+Landmark Specifications:
+
+- **Shape**: Landmarks must be flat and defined as a polygon with exactly four vertices.
+- **Vertex Definition**: Vertices must be defined in a counter-clockwise order.
+- **Coordinate System** and Vertex Order:
+  - The x-axis must be parallel to the vector extending from the first vertex to the second vertex.
+  - The y-axis must be parallel to the vector extending from the second vertex to the third vertex.
+- **Required Attributes**:
+  - Specify pose_marker for type `<tag k="type" v="pose_marker"/>`
+  - Specify the type of the landmark for subtype `<tag k="subtype" v="apriltag_16h5"/>`
+  - Specify the ID of the landmark for marker_id `<tag k="marker_id" v="0"/>`
+    - ID can be assigned arbitrarily as a string, but the same ID must be assigned for the same marker type
+    - For example, apiltag_16h5 has 30 different IDs from 0 to 29. If multiple tags of the same type are to be placed in one environment, they should be assigned the same ID.
+
+![localization_landmark](./localization_landmark.drawio.svg)
+
+_An example:_
+
+```xml
+...
+
+  <node id="1" lat="35.8xxxxx" lon="139.6xxxxx">
+    <tag k="mgrs_code" v="99XXX000000"/>
+    <tag k="local_x" v="22.2356"/>
+    <tag k="local_y" v="87.4506"/>
+    <tag k="ele" v="2.1725"/>
+  </node>
+  <node id="2" lat="35.8xxxxx" lon="139.6xxxxx">
+    <tag k="mgrs_code" v="99XXX000000"/>
+    <tag k="local_x" v="22.639"/>
+    <tag k="local_y" v="87.5886"/>
+    <tag k="ele" v="2.5947"/>
+  </node>
+  <node id="3" lat="35.8xxxxx" lon="139.6xxxxx">
+    <tag k="mgrs_code" v="99XXX000000"/>
+    <tag k="local_x" v="22.2331"/>
+    <tag k="local_y" v="87.4713"/>
+    <tag k="ele" v="3.0208"/>
+  </node>
+  <node id="4" lat="35.8xxxxx" lon="139.6xxxxx">
+    <tag k="mgrs_code" v="99XXX000000"/>
+    <tag k="local_x" v="21.8298"/>
+    <tag k="local_y" v="87.3332"/>
+    <tag k="ele" v="2.5985"/>
+  </node>
+
+...
+
+  <way id="5">
+    <nd ref="1"/>
+    <nd ref="2"/>
+    <nd ref="3"/>
+    <nd ref="4"/>
+    <tag k="type" v="pose_marker"/>
+    <tag k="subtype" v="apriltag_16h5"/>
+    <tag k="area" v="yes"/>
+    <tag k="marker_id" v="0"/>
+  </way>
+
+...
+
+```

--- a/tmp/lanelet2_extension/docs/localization_landmark.drawio.svg
+++ b/tmp/lanelet2_extension/docs/localization_landmark.drawio.svg
@@ -1,0 +1,156 @@
+<svg
+  host="65bd71144e"
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  version="1.1"
+  width="336px"
+  height="336px"
+  viewBox="-0.5 -0.5 336 336"
+  content="&lt;mxfile&gt;&lt;diagram id=&quot;z_GJx55S16-dNHi1224P&quot; name=&quot;ページ1&quot;&gt;5ZhNb6MwEIZ/DdLuDWwC9Nhm2+5hV1ophz1beAJWDY6Mk5D++jXFfNmJkgNNqk0OEbz+wPPMeDzg4WVRv0qyyX8LCtxDPq09/MNDCCeJ/m+EQytEKGyFTDLaSsEgrNg7GNE36pZRqCYdlRBcsc1UTEVZQqomGpFS7Kfd1oJPn7ohGTjCKiXcVf8yqvJWTVA86D+BZXn35CB6aFsK0nU2llQ5oWI/kvCzh5dSCNVeFfUSeMOu49KOeznR2i9MQqkuGRAu2hE7wrfGOLMwdeislWJbUmgG+B5+2udMwWpD0qZ1r92rtVwVXN8F+tJdgFnTDqSCeiSZBb2CKEDJg+7StUYGjomOoIO1H1j3ffIx504kxr9ZP/eAQF8YCieIRA6RwEGih+hYg/M4SLVpA3DN6gbhLHzCKR+UuHzQETxoDjqxQ8cNmJvSweiGdBKHDv7adAL/inQeHDrh16Jj76xr0ln45zMxlPSxOb70XcpJVbH0wuQLdHKguQBGBi6OGNhpEjhRbDfNi8esNk/4I5heSc83sbamb3GrxFamYAaNTy1rntA/M5EiMgPlTPThg97qy9wSOG6pHb/o8FJTT1RKijdYCi6kVkpRNhG9ZpxbEuEsKxt3ao+B1p+aYGW60ng0DQWjlJ/aDtOTeS1KZWqlIJopXcTWhojdDYGPxAueY0Mgh/zhfsj3te6hC/nrgcf/fyZCVqbHdul4aSqyJwo/LxOFF7jllqcnsmuLK1ZeC7dqnxHOOH14eo99/OaCFlvQYgda5DKLZkDmlvLv95NfgweLe4Svl2Dd14RfpKQFkW/fXqS29fv9+CE5e8wFwTxu0LfDd5U2/w4fp/DzPw==&lt;/diagram&gt;&lt;/mxfile&gt;"
+>
+  <defs/>
+  <g>
+    <rect x="87" y="87" width="160" height="160" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+    <ellipse cx="77" cy="257" rx="10" ry="10" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+    <g transform="translate(-0.5 -0.5)">
+      <switch>
+        <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 18px; height: 1px; padding-top: 257px; margin-left: 68px;">
+            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+              <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                1
+              </div>
+            </div>
+          </div>
+        </foreignObject>
+        <text x="77" y="261" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">1</text>
+      </switch>
+    </g>
+    <ellipse cx="257" cy="257" rx="10" ry="10" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+    <g transform="translate(-0.5 -0.5)">
+      <switch>
+        <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+          <div
+            xmlns="http://www.w3.org/1999/xhtml"
+            style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 18px; height: 1px; padding-top: 257px; margin-left: 248px;"
+          >
+            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+              <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                2
+              </div>
+            </div>
+          </div>
+        </foreignObject>
+        <text x="257" y="261" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">2</text>
+      </switch>
+    </g>
+    <ellipse cx="257" cy="77" rx="10" ry="10" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+    <g transform="translate(-0.5 -0.5)">
+      <switch>
+        <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 18px; height: 1px; padding-top: 77px; margin-left: 248px;">
+            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+              <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                3
+              </div>
+            </div>
+          </div>
+        </foreignObject>
+        <text x="257" y="81" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">3</text>
+      </switch>
+    </g>
+    <ellipse cx="77" cy="77" rx="10" ry="10" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+    <g transform="translate(-0.5 -0.5)">
+      <switch>
+        <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 18px; height: 1px; padding-top: 77px; margin-left: 68px;">
+            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+              <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                4
+              </div>
+            </div>
+          </div>
+        </foreignObject>
+        <text x="77" y="81" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">4</text>
+      </switch>
+    </g>
+    <path d="M 7 167 L 320.63 167" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+    <path d="M 325.88 167 L 318.88 170.5 L 320.63 167 L 318.88 163.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+    <rect x="297" y="137" width="30" height="30" fill="none" stroke="none" pointer-events="all"/>
+    <g transform="translate(-0.5 -0.5)">
+      <switch>
+        <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+          <div
+            xmlns="http://www.w3.org/1999/xhtml"
+            style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 28px; height: 1px; padding-top: 152px; margin-left: 298px;"
+          >
+            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+              <div style="display: inline-block; font-size: 16px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                x
+              </div>
+            </div>
+          </div>
+        </foreignObject>
+        <text x="312" y="157" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="16px" text-anchor="middle">x</text>
+      </switch>
+    </g>
+    <rect x="137" y="7" width="30" height="30" fill="none" stroke="none" pointer-events="all"/>
+    <g transform="translate(-0.5 -0.5)">
+      <switch>
+        <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 28px; height: 1px; padding-top: 22px; margin-left: 138px;">
+            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+              <div style="display: inline-block; font-size: 16px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                y
+              </div>
+            </div>
+          </div>
+        </foreignObject>
+        <text x="152" y="27" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="16px" text-anchor="middle">y</text>
+      </switch>
+    </g>
+    <path d="M 167 327 L 167 13.37" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+    <path d="M 167 8.12 L 170.5 15.12 L 167 13.37 L 163.5 15.12 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+    <ellipse cx="157" cy="157" rx="10" ry="10" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+    <ellipse cx="157" cy="157" rx="3" ry="3" fill="#000000" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+    <rect x="124" y="130" width="30" height="30" fill="none" stroke="none" pointer-events="all"/>
+    <g transform="translate(-0.5 -0.5)">
+      <switch>
+        <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+          <div
+            xmlns="http://www.w3.org/1999/xhtml"
+            style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 28px; height: 1px; padding-top: 145px; margin-left: 125px;"
+          >
+            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+              <div style="display: inline-block; font-size: 16px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                z
+              </div>
+            </div>
+          </div>
+        </foreignObject>
+        <text x="139" y="150" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="16px" text-anchor="middle">z</text>
+      </switch>
+    </g>
+    <rect x="7" y="7" width="110" height="30" fill="none" stroke="none" pointer-events="all"/>
+    <g transform="translate(-0.5 -0.5)">
+      <switch>
+        <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 108px; height: 1px; padding-top: 22px; margin-left: 8px;">
+            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+              <div style="display: inline-block; font-size: 16px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                Landmark(Front)
+              </div>
+            </div>
+          </div>
+        </foreignObject>
+        <text x="62" y="27" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="16px" text-anchor="middle">Landmark(Front)</text>
+      </switch>
+    </g>
+  </g>
+  <switch>
+    <g requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"/>
+    <a transform="translate(0,-5)" xlink:href="https://www.diagrams.net/doc/faq/svg-export-text-problems" target="_blank">
+      <text text-anchor="middle" font-size="10px" x="50%" y="100%">Text is not SVG - cannot display</text>
+    </a>
+  </switch>
+</svg>

--- a/tmp/lanelet2_extension/include/lanelet2_extension/localization/landmark.hpp
+++ b/tmp/lanelet2_extension/include/lanelet2_extension/localization/landmark.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LANELET2_EXTENSION__LOCALIZATION_LANDMARK__LANDMARK_MANAGER_HPP_
-#define LANELET2_EXTENSION__LOCALIZATION_LANDMARK__LANDMARK_MANAGER_HPP_
+#ifndef LANELET2_EXTENSION__LOCALIZATION__LANDMARK_HPP_
+#define LANELET2_EXTENSION__LOCALIZATION__LANDMARK_HPP_
 
 #include "autoware_auto_mapping_msgs/msg/had_map_bin.hpp"
 #include <geometry_msgs/msg/pose.hpp>
@@ -36,4 +36,4 @@ std::vector<Landmark> parseLandmarks(
 
 }  // namespace lanelet::localization
 
-#endif  // LANELET2_EXTENSION__LOCALIZATION_LANDMARK__LANDMARK_MANAGER_HPP_
+#endif  // LANELET2_EXTENSION__LOCALIZATION__LANDMARK_HPP_

--- a/tmp/lanelet2_extension/include/lanelet2_extension/localization/landmark.hpp
+++ b/tmp/lanelet2_extension/include/lanelet2_extension/localization/landmark.hpp
@@ -16,7 +16,8 @@
 #define LANELET2_EXTENSION__LOCALIZATION__LANDMARK_HPP_
 
 #include "autoware_auto_mapping_msgs/msg/had_map_bin.hpp"
-#include <geometry_msgs/msg/pose.hpp>
+
+#include <lanelet2_core/primitives/Polygon.h>
 
 #include <string>
 #include <vector>
@@ -24,15 +25,9 @@
 namespace lanelet::localization
 {
 
-struct Landmark
-{
-  std::string id;
-  geometry_msgs::msg::Pose pose;
-};
-
-std::vector<Landmark> parseLandmarks(
+std::vector<lanelet::Polygon3d> parseLandmarkPolygons(
   const autoware_auto_mapping_msgs::msg::HADMapBin::ConstSharedPtr & msg,
-  const std::string & target_subtype, const double volume_threshold = 1e-5);
+  const std::string & target_subtype);
 
 }  // namespace lanelet::localization
 

--- a/tmp/lanelet2_extension/include/lanelet2_extension/localization/landmark.hpp
+++ b/tmp/lanelet2_extension/include/lanelet2_extension/localization/landmark.hpp
@@ -1,0 +1,39 @@
+// Copyright 2023 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef LANELET2_EXTENSION__LOCALIZATION_LANDMARK__LANDMARK_MANAGER_HPP_
+#define LANELET2_EXTENSION__LOCALIZATION_LANDMARK__LANDMARK_MANAGER_HPP_
+
+#include "autoware_auto_mapping_msgs/msg/had_map_bin.hpp"
+#include <geometry_msgs/msg/pose.hpp>
+
+#include <string>
+#include <vector>
+
+namespace lanelet::localization
+{
+
+struct Landmark
+{
+  std::string id;
+  geometry_msgs::msg::Pose pose;
+};
+
+std::vector<Landmark> parseLandmarks(
+  const autoware_auto_mapping_msgs::msg::HADMapBin::ConstSharedPtr & msg,
+  const std::string & target_subtype, const double volume_threshold = 1e-5);
+
+}  // namespace lanelet::localization
+
+#endif  // LANELET2_EXTENSION__LOCALIZATION_LANDMARK__LANDMARK_MANAGER_HPP_

--- a/tmp/lanelet2_extension/include/lanelet2_extension/localization/landmark.hpp
+++ b/tmp/lanelet2_extension/include/lanelet2_extension/localization/landmark.hpp
@@ -22,6 +22,8 @@
 #include <string>
 #include <vector>
 
+// NOLINTBEGIN(readability-identifier-naming)
+
 namespace lanelet::localization
 {
 
@@ -30,5 +32,7 @@ std::vector<lanelet::Polygon3d> parseLandmarkPolygons(
   const std::string & target_subtype);
 
 }  // namespace lanelet::localization
+
+// NOLINTEND(readability-identifier-naming)
 
 #endif  // LANELET2_EXTENSION__LOCALIZATION__LANDMARK_HPP_

--- a/tmp/lanelet2_extension/lib/landmark.cpp
+++ b/tmp/lanelet2_extension/lib/landmark.cpp
@@ -1,0 +1,97 @@
+// Copyright 2023 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lanelet2_extension/localization/landmark.hpp"
+
+#include "lanelet2_extension/utility/message_conversion.hpp"
+
+#include <Eigen/Core>
+#include <tf2_eigen/tf2_eigen.hpp>
+
+#include <lanelet2_core/LaneletMap.h>
+#include <lanelet2_core/primitives/Polygon.h>
+
+namespace lanelet::localization
+{
+
+std::vector<Landmark> parseLandmarks(
+  const autoware_auto_mapping_msgs::msg::HADMapBin::ConstSharedPtr & msg,
+  const std::string & target_subtype, const double volume_threshold)
+{
+  lanelet::LaneletMapPtr lanelet_map_ptr{std::make_shared<lanelet::LaneletMap>()};
+  lanelet::utils::conversion::fromBinMsg(*msg, lanelet_map_ptr);
+
+  std::vector<Landmark> landmarks;
+
+  for (const auto & poly : lanelet_map_ptr->polygonLayer) {
+    const std::string type{poly.attributeOr(lanelet::AttributeName::Type, "none")};
+    if (type != "pose_marker") {
+      continue;
+    }
+    const std::string subtype{poly.attributeOr(lanelet::AttributeName::Subtype, "none")};
+    if (subtype != target_subtype) {
+      continue;
+    }
+
+    // Get landmark_id
+    const std::string landmark_id = poly.attributeOr("marker_id", "none");
+
+    // Get 4 vertices
+    const auto & vertices = poly.basicPolygon();
+    if (vertices.size() != 4) {
+      continue;
+    }
+
+    // 4 vertices represent the landmark vertices in counterclockwise order
+    // Calculate the volume by considering it as a tetrahedron
+    const auto & v0 = vertices[0];
+    const auto & v1 = vertices[1];
+    const auto & v2 = vertices[2];
+    const auto & v3 = vertices[3];
+    const double volume = (v1 - v0).cross(v2 - v0).dot(v3 - v0) / 6.0;
+    if (volume > volume_threshold) {
+      continue;
+    }
+
+    // Calculate the center of the quadrilateral
+    const auto center = (v0 + v1 + v2 + v3) / 4.0;
+
+    // Define axes
+    const auto x_axis = (v1 - v0).normalized();
+    const auto y_axis = (v2 - v1).normalized();
+    const auto z_axis = x_axis.cross(y_axis).normalized();
+
+    // Construct rotation matrix and convert it to quaternion
+    Eigen::Matrix3d rotation_matrix;
+    rotation_matrix << x_axis, y_axis, z_axis;
+    const Eigen::Quaterniond q{rotation_matrix};
+
+    // Create Pose
+    geometry_msgs::msg::Pose pose;
+    pose.position.x = center.x();
+    pose.position.y = center.y();
+    pose.position.z = center.z();
+    pose.orientation.x = q.x();
+    pose.orientation.y = q.y();
+    pose.orientation.z = q.z();
+    pose.orientation.w = q.w();
+
+    // Add
+    landmarks.push_back(Landmark{landmark_id, pose});
+  }
+
+  return landmarks;
+}
+
+}  // namespace lanelet::localization

--- a/tmp/lanelet2_extension/lib/landmark.cpp
+++ b/tmp/lanelet2_extension/lib/landmark.cpp
@@ -17,22 +17,20 @@
 #include "lanelet2_extension/utility/message_conversion.hpp"
 
 #include <Eigen/Core>
-#include <tf2_eigen/tf2_eigen.hpp>
 
 #include <lanelet2_core/LaneletMap.h>
-#include <lanelet2_core/primitives/Polygon.h>
 
 namespace lanelet::localization
 {
 
-std::vector<Landmark> parseLandmarks(
+std::vector<lanelet::Polygon3d> parseLandmarkPolygons(
   const autoware_auto_mapping_msgs::msg::HADMapBin::ConstSharedPtr & msg,
-  const std::string & target_subtype, const double volume_threshold)
+  const std::string & target_subtype)
 {
   lanelet::LaneletMapPtr lanelet_map_ptr{std::make_shared<lanelet::LaneletMap>()};
   lanelet::utils::conversion::fromBinMsg(*msg, lanelet_map_ptr);
 
-  std::vector<Landmark> landmarks;
+  std::vector<lanelet::Polygon3d> landmarks;
 
   for (const auto & poly : lanelet_map_ptr->polygonLayer) {
     const std::string type{poly.attributeOr(lanelet::AttributeName::Type, "none")};
@@ -43,52 +41,7 @@ std::vector<Landmark> parseLandmarks(
     if (subtype != target_subtype) {
       continue;
     }
-
-    // Get landmark_id
-    const std::string landmark_id = poly.attributeOr("marker_id", "none");
-
-    // Get 4 vertices
-    const auto & vertices = poly.basicPolygon();
-    if (vertices.size() != 4) {
-      continue;
-    }
-
-    // 4 vertices represent the landmark vertices in counterclockwise order
-    // Calculate the volume by considering it as a tetrahedron
-    const auto & v0 = vertices[0];
-    const auto & v1 = vertices[1];
-    const auto & v2 = vertices[2];
-    const auto & v3 = vertices[3];
-    const double volume = (v1 - v0).cross(v2 - v0).dot(v3 - v0) / 6.0;
-    if (volume > volume_threshold) {
-      continue;
-    }
-
-    // Calculate the center of the quadrilateral
-    const auto center = (v0 + v1 + v2 + v3) / 4.0;
-
-    // Define axes
-    const auto x_axis = (v1 - v0).normalized();
-    const auto y_axis = (v2 - v1).normalized();
-    const auto z_axis = x_axis.cross(y_axis).normalized();
-
-    // Construct rotation matrix and convert it to quaternion
-    Eigen::Matrix3d rotation_matrix;
-    rotation_matrix << x_axis, y_axis, z_axis;
-    const Eigen::Quaterniond q{rotation_matrix};
-
-    // Create Pose
-    geometry_msgs::msg::Pose pose;
-    pose.position.x = center.x();
-    pose.position.y = center.y();
-    pose.position.z = center.z();
-    pose.orientation.x = q.x();
-    pose.orientation.y = q.y();
-    pose.orientation.z = q.z();
-    pose.orientation.w = q.w();
-
-    // Add
-    landmarks.push_back(Landmark{landmark_id, pose});
+    landmarks.push_back(poly);
   }
 
   return landmarks;

--- a/tmp/lanelet2_extension/package.xml
+++ b/tmp/lanelet2_extension/package.xml
@@ -27,7 +27,6 @@
   <depend>range-v3</depend>
   <depend>rclcpp</depend>
   <depend>tf2</depend>
-  <depend>tf2_eigen</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>visualization_msgs</depend>
 

--- a/tmp/lanelet2_extension/package.xml
+++ b/tmp/lanelet2_extension/package.xml
@@ -27,6 +27,7 @@
   <depend>range-v3</depend>
   <depend>rclcpp</depend>
   <depend>tf2</depend>
+  <depend>tf2_eigen</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>visualization_msgs</depend>
 


### PR DESCRIPTION
## Description

Added localization landmark.

This new lanelet2 definition is related to the `landmark_based_localizer` in autoware.universe.

<https://github.com/autowarefoundation/autoware.universe/tree/main/localization/landmark_based_localizer>

Related pull request https://github.com/autowarefoundation/autoware.universe/pull/5803

## Tests performed

It has been confirmed that the `logging_simulator` with `pose_source:=artag` runs with the same accuracy as before on AWSIM data with GT.

## Effects on system behavior

There is no effect except for `ar_tag_based_localizer`, and there is no change in the behavior of `ar_tag_based_localizer`. Just moved the definition code.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
