### PR TITLE
refactor(lanelet2_extension): move RegisterRegulatoryElement to cpp file

### DIFF
--- a/tmp/lanelet2_extension/include/lanelet2_extension/regulatory_elements/autoware_traffic_light.hpp
+++ b/tmp/lanelet2_extension/include/lanelet2_extension/regulatory_elements/autoware_traffic_light.hpp
@@ -67,22 +67,22 @@ public:
   void addLightBulbs(const LineStringOrPolygon3d & primitive);
 
   /**
-p   * @brief remove a traffic light bulb
+   * @brief remove a traffic light bulb
    * @param primitive the primitive
    * @return true if the traffic light bulb existed and was removed
    */
   bool removeLightBulbs(const LineStringOrPolygon3d & primitive);
 
 private:
-  // the following lines are required so that lanelet2 can create this object
-  // when loading a map with this regulatory element
-  friend class lanelet::RegisterRegulatoryElement<AutowareTrafficLight>;
   AutowareTrafficLight(
     Id id, const AttributeMap & attributes, const LineStringsOrPolygons3d & trafficLights,
     const Optional<LineString3d> & stopLine, const LineStrings3d & lightBulbs);
+
+  // the following lines are required so that lanelet2 can create this object
+  // when loading a map with this regulatory element
+  friend class RegisterRegulatoryElement<AutowareTrafficLight>;
   explicit AutowareTrafficLight(const lanelet::RegulatoryElementDataPtr & data);
 };
-static lanelet::RegisterRegulatoryElement<AutowareTrafficLight> regAutowareTraffic;
 
 }  // namespace lanelet::autoware
 

--- a/tmp/lanelet2_extension/include/lanelet2_extension/regulatory_elements/crosswalk.hpp
+++ b/tmp/lanelet2_extension/include/lanelet2_extension/regulatory_elements/crosswalk.hpp
@@ -75,15 +75,15 @@ public:
   bool removeCrosswalkArea(const Polygon3d & primitive);
 
 private:
-  // the following lines are required so that lanelet2 can create this object
-  // when loading a map with this regulatory element
-  friend class lanelet::RegisterRegulatoryElement<Crosswalk>;
   Crosswalk(
     Id id, const AttributeMap & attributes, const Lanelet & crosswalk_lanelet,
     const Polygon3d & crosswalk_area, const LineStrings3d & stop_line);
+
+  // the following lines are required so that lanelet2 can create this object
+  // when loading a map with this regulatory element
+  friend class RegisterRegulatoryElement<Crosswalk>;
   explicit Crosswalk(const lanelet::RegulatoryElementDataPtr & data);
 };
-static lanelet::RegisterRegulatoryElement<Crosswalk> regCrosswalk;
 
 }  // namespace lanelet::autoware
 

--- a/tmp/lanelet2_extension/include/lanelet2_extension/regulatory_elements/detection_area.hpp
+++ b/tmp/lanelet2_extension/include/lanelet2_extension/regulatory_elements/detection_area.hpp
@@ -79,15 +79,15 @@ public:
   void removeStopLine();
 
 private:
-  // the following lines are required so that lanelet2 can create this object
-  // when loading a map with this regulatory element
-  friend class lanelet::RegisterRegulatoryElement<DetectionArea>;
   DetectionArea(
     Id id, const AttributeMap & attributes, const Polygons3d & detectionAreas,
     const LineString3d & stopLine);
+
+  // the following lines are required so that lanelet2 can create this object
+  // when loading a map with this regulatory element
+  friend class RegisterRegulatoryElement<DetectionArea>;
   explicit DetectionArea(const lanelet::RegulatoryElementDataPtr & data);
 };
-static lanelet::RegisterRegulatoryElement<DetectionArea> regDetectionArea;
 
 }  // namespace lanelet::autoware
 

--- a/tmp/lanelet2_extension/include/lanelet2_extension/regulatory_elements/no_parking_area.hpp
+++ b/tmp/lanelet2_extension/include/lanelet2_extension/regulatory_elements/no_parking_area.hpp
@@ -57,13 +57,13 @@ public:
   bool removeNoParkingArea(const Polygon3d & primitive);
 
 private:
+  NoParkingArea(Id id, const AttributeMap & attributes, const Polygons3d & no_parking_area);
+
   // the following lines are required so that lanelet2 can create this object
   // when loading a map with this regulatory element
-  friend class lanelet::RegisterRegulatoryElement<NoParkingArea>;
-  NoParkingArea(Id id, const AttributeMap & attributes, const Polygons3d & no_parking_area);
+  friend class RegisterRegulatoryElement<NoParkingArea>;
   explicit NoParkingArea(const lanelet::RegulatoryElementDataPtr & data);
 };
-static lanelet::RegisterRegulatoryElement<NoParkingArea> regNoParkingArea;
 
 }  // namespace lanelet::autoware
 

--- a/tmp/lanelet2_extension/include/lanelet2_extension/regulatory_elements/no_stopping_area.hpp
+++ b/tmp/lanelet2_extension/include/lanelet2_extension/regulatory_elements/no_stopping_area.hpp
@@ -77,15 +77,15 @@ public:
   void removeStopLine();
 
 private:
-  // the following lines are required so that lanelet2 can create this object
-  // when loading a map with this regulatory element
-  friend class lanelet::RegisterRegulatoryElement<NoStoppingArea>;
   NoStoppingArea(
     Id id, const AttributeMap & attributes, const Polygons3d & no_stopping_area,
     const Optional<LineString3d> & stopLine);
+
+  // the following lines are required so that lanelet2 can create this object
+  // when loading a map with this regulatory element
+  friend class RegisterRegulatoryElement<NoStoppingArea>;
   explicit NoStoppingArea(const lanelet::RegulatoryElementDataPtr & data);
 };
-static lanelet::RegisterRegulatoryElement<NoStoppingArea> regNoStoppingArea;
 
 }  // namespace lanelet::autoware
 

--- a/tmp/lanelet2_extension/include/lanelet2_extension/regulatory_elements/road_marking.hpp
+++ b/tmp/lanelet2_extension/include/lanelet2_extension/regulatory_elements/road_marking.hpp
@@ -57,13 +57,13 @@ public:
   void removeRoadMarking();
 
 private:
+  RoadMarking(Id id, const AttributeMap & attributes, const LineString3d & road_marking);
+
   // the following lines are required so that lanelet2 can create this object
   // when loading a map with this regulatory element
-  friend class lanelet::RegisterRegulatoryElement<RoadMarking>;
-  RoadMarking(Id id, const AttributeMap & attributes, const LineString3d & road_marking);
+  friend class RegisterRegulatoryElement<RoadMarking>;
   explicit RoadMarking(const lanelet::RegulatoryElementDataPtr & data);
 };
-static lanelet::RegisterRegulatoryElement<RoadMarking> regRoadMarking;
 
 }  // namespace lanelet::autoware
 

--- a/tmp/lanelet2_extension/include/lanelet2_extension/regulatory_elements/speed_bump.hpp
+++ b/tmp/lanelet2_extension/include/lanelet2_extension/regulatory_elements/speed_bump.hpp
@@ -59,13 +59,13 @@ public:
   bool removeSpeedBump(const Polygon3d & primitive);
 
 private:
+  SpeedBump(Id id, const AttributeMap & attributes, const Polygon3d & speed_bump);
+
   // the following lines are required so that lanelet2 can create this object
   // when loading a map with this regulatory element
-  friend class lanelet::RegisterRegulatoryElement<SpeedBump>;
-  SpeedBump(Id id, const AttributeMap & attributes, const Polygon3d & speed_bump);
+  friend class RegisterRegulatoryElement<SpeedBump>;
   explicit SpeedBump(const lanelet::RegulatoryElementDataPtr & data);
 };
-static lanelet::RegisterRegulatoryElement<SpeedBump> regSpeedBump;
 
 }  // namespace lanelet::autoware
 

--- a/tmp/lanelet2_extension/include/lanelet2_extension/regulatory_elements/virtual_traffic_light.hpp
+++ b/tmp/lanelet2_extension/include/lanelet2_extension/regulatory_elements/virtual_traffic_light.hpp
@@ -63,17 +63,14 @@ public:
   }
 
 private:
-  // the following lines are required so that lanelet2 can create this object
-  // when loading a map with this regulatory element
-  friend class lanelet::RegisterRegulatoryElement<VirtualTrafficLight>;
-
   VirtualTrafficLight(
     const Id id, const AttributeMap & attributes, const LineString3d & virtual_traffic_light);
 
+  // the following lines are required so that lanelet2 can create this object
+  // when loading a map with this regulatory element
+  friend class RegisterRegulatoryElement<VirtualTrafficLight>;
   explicit VirtualTrafficLight(const lanelet::RegulatoryElementDataPtr & data);
 };
-
-static lanelet::RegisterRegulatoryElement<VirtualTrafficLight> regVirtualTrafficLight;
 
 }  // namespace lanelet::autoware
 

--- a/tmp/lanelet2_extension/lib/autoware_traffic_light.cpp
+++ b/tmp/lanelet2_extension/lib/autoware_traffic_light.cpp
@@ -142,6 +142,8 @@ bool AutowareTrafficLight::removeLightBulbs(const LineStringOrPolygon3d & primit
     primitive.asRuleParameter(), &parameters().find(AutowareRoleNameString::LightBulbs)->second);
 }
 
+RegisterRegulatoryElement<AutowareTrafficLight> regAutowareTrafficLight;
+
 }  // namespace lanelet::autoware
 
 // NOLINTEND(readability-identifier-naming)

--- a/tmp/lanelet2_extension/lib/crosswalk.cpp
+++ b/tmp/lanelet2_extension/lib/crosswalk.cpp
@@ -124,6 +124,9 @@ bool Crosswalk::removeCrosswalkArea(const Polygon3d & primitive)
 {
   return findAndErase(primitive, &parameters().find("crosswalk")->second);
 }
+
+RegisterRegulatoryElement<Crosswalk> regCrosswalk;
+
 }  // namespace lanelet::autoware
 
 // NOLINTEND(readability-identifier-naming)

--- a/tmp/lanelet2_extension/lib/detection_area.cpp
+++ b/tmp/lanelet2_extension/lib/detection_area.cpp
@@ -155,6 +155,8 @@ void DetectionArea::removeStopLine()
   parameters()[RoleName::RefLine] = {};
 }
 
+RegisterRegulatoryElement<DetectionArea> regDetectionArea;
+
 }  // namespace lanelet::autoware
 
 // NOLINTEND(readability-identifier-naming)

--- a/tmp/lanelet2_extension/lib/no_parking_area.cpp
+++ b/tmp/lanelet2_extension/lib/no_parking_area.cpp
@@ -126,6 +126,9 @@ bool NoParkingArea::removeNoParkingArea(const Polygon3d & primitive)
 {
   return findAndErase(primitive, &parameters().find("no_parking_area")->second);
 }
+
+RegisterRegulatoryElement<NoParkingArea> regNoParkingArea;
+
 }  // namespace lanelet::autoware
 
 // NOLINTEND(readability-identifier-naming)

--- a/tmp/lanelet2_extension/lib/no_stopping_area.cpp
+++ b/tmp/lanelet2_extension/lib/no_stopping_area.cpp
@@ -155,6 +155,8 @@ void NoStoppingArea::removeStopLine()
   parameters()[RoleName::RefLine] = {};
 }
 
+RegisterRegulatoryElement<NoStoppingArea> regNoStoppingArea;
+
 }  // namespace lanelet::autoware
 
 // NOLINTEND(readability-identifier-naming)

--- a/tmp/lanelet2_extension/lib/road_marking.cpp
+++ b/tmp/lanelet2_extension/lib/road_marking.cpp
@@ -75,6 +75,8 @@ void RoadMarking::removeRoadMarking()
   parameters()[RoleName::Refers] = {};
 }
 
+RegisterRegulatoryElement<RoadMarking> regRoadMarking;
+
 }  // namespace lanelet::autoware
 
 // NOLINTEND(readability-identifier-naming)

--- a/tmp/lanelet2_extension/lib/speed_bump.cpp
+++ b/tmp/lanelet2_extension/lib/speed_bump.cpp
@@ -115,6 +115,8 @@ bool SpeedBump::removeSpeedBump(const Polygon3d & primitive)
   return findAndErase(primitive, &parameters().find("speed_bump")->second);
 }
 
+RegisterRegulatoryElement<SpeedBump> regSpeedBump;
+
 }  // namespace lanelet::autoware
 
 // NOLINTEND(readability-identifier-naming)

--- a/tmp/lanelet2_extension/lib/virtual_traffic_light.cpp
+++ b/tmp/lanelet2_extension/lib/virtual_traffic_light.cpp
@@ -60,6 +60,8 @@ VirtualTrafficLight::VirtualTrafficLight(
 {
 }
 
+RegisterRegulatoryElement<VirtualTrafficLight> regVirtualTrafficLight;
+
 }  // namespace lanelet::autoware
 
 // NOLINTEND(readability-identifier-naming)


### PR DESCRIPTION
## Description

> To register a class, put
> RegisterRegulatoryElement<MyClass> regMyClass;
> somewhere in your cpp file.

Follow [this comment](https://github.com/fzi-forschungszentrum-informatik/Lanelet2/blob/master/lanelet2_core/include/lanelet2_core/primitives/RegulatoryElement.h#L375-L377) to move `RegisterRegulatoryElement` to cpp file. Also, remove redundant namespace and move the constructor to match the comment about object creation.

## Related links

None

## Tests performed

Check if lanelet2 map can be loaded using simple planning simulator.

## Notes for reviewers

None

## Interface changes

None

## Effects on system behavior

None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
