### PR TITLE
fix(lanelet2_extension): improve traffic regulatory element id visualization

### DIFF
--- a/tmp/lanelet2_extension/include/lanelet2_extension/visualization/visualization.hpp
+++ b/tmp/lanelet2_extension/include/lanelet2_extension/visualization/visualization.hpp
@@ -187,16 +187,29 @@ visualization_msgs::msg::MarkerArray autowareTrafficLightsAsMarkerArray(
   const double scale = 1.0);
 
 /**
- * [generateTrafficLightIdMaker creates marker array to visualize traffic id
- * lights]
+ * [generateTrafficLightRegulatoryElementIdMaker creates marker array to visualize traffic
+ * light regulatory element ids]
  * @param lanelets      [lanelets]
  * @param  c            [color of the marker]
  * @param  duration     [lifetime of the marker]
  * @return              [created marker array]
  */
-visualization_msgs::msg::MarkerArray generateTrafficLightIdMaker(
+visualization_msgs::msg::MarkerArray generateTrafficLightRegulatoryElementIdMaker(
   const lanelet::ConstLanelets & lanelets, const std_msgs::msg::ColorRGBA & c,
-  const rclcpp::Duration & duration = rclcpp::Duration(0, 0), const double scale = 1.0);
+  const rclcpp::Duration & duration = rclcpp::Duration(0, 0), const double scale = 0.5);
+
+/**
+ * [generateTrafficLightIdMarkerArray creates marker array to visualize traffic
+ * light ids]
+ * @param  tl_reg_elems [traffic light regulatory elements]
+ * @param  c            [color of the marker]
+ * @param  duration     [lifetime of the marker]
+ * @return              [created marker array]
+ */
+visualization_msgs::msg::MarkerArray generateTrafficLightIdMaker(
+  const std::vector<lanelet::AutowareTrafficLightConstPtr> & tl_reg_elems,
+  const std_msgs::msg::ColorRGBA & c, const rclcpp::Duration & duration = rclcpp::Duration(0, 0),
+  const double scale = 0.5);
 
 /**
  * [trafficLightsAsTriangleMarkerArray creates marker array to visualize shape

--- a/tmp/lanelet2_extension/include/lanelet2_extension/visualization/visualization.hpp
+++ b/tmp/lanelet2_extension/include/lanelet2_extension/visualization/visualization.hpp
@@ -189,15 +189,14 @@ visualization_msgs::msg::MarkerArray autowareTrafficLightsAsMarkerArray(
 /**
  * [generateTrafficLightIdMaker creates marker array to visualize traffic id
  * lights]
- * @param  tl_reg_elems [traffic light regulatory elements]
+ * @param lanelets      [lanelets]
  * @param  c            [color of the marker]
  * @param  duration     [lifetime of the marker]
  * @return              [created marker array]
  */
 visualization_msgs::msg::MarkerArray generateTrafficLightIdMaker(
-  const std::vector<lanelet::AutowareTrafficLightConstPtr> & tl_reg_elems,
-  const std_msgs::msg::ColorRGBA & c, const rclcpp::Duration & duration = rclcpp::Duration(0, 0),
-  const double scale = 1.0);
+  const lanelet::ConstLanelets & lanelets, const std_msgs::msg::ColorRGBA & c,
+  const rclcpp::Duration & duration = rclcpp::Duration(0, 0), const double scale = 1.0);
 
 /**
  * [trafficLightsAsTriangleMarkerArray creates marker array to visualize shape

--- a/tmp/lanelet2_extension/lib/visualization.cpp
+++ b/tmp/lanelet2_extension/lib/visualization.cpp
@@ -612,7 +612,7 @@ visualization_msgs::msg::MarkerArray visualization::generateTrafficLightIdMaker(
         marker.frame_locked = false;
 
         std::ostringstream string_stream;
-        string_stream << "Refferer:" << element->id() << ", ";
+        string_stream << "referrer:" << element->id() << ", ";
         marker.text = string_stream.str();
         traffic_light_map.emplace(line.id(), marker);
       } else {

--- a/tmp/lanelet2_extension/lib/visualization.cpp
+++ b/tmp/lanelet2_extension/lib/visualization.cpp
@@ -612,12 +612,12 @@ visualization_msgs::msg::MarkerArray visualization::generateTrafficLightIdMaker(
         marker.frame_locked = false;
 
         std::ostringstream string_stream;
-        string_stream << "referrer:" << element->id() << ", ";
+        string_stream << "referrer:" << element->id() << ",";
         marker.text = string_stream.str();
         traffic_light_map.emplace(line.id(), marker);
       } else {
         std::ostringstream string_stream;
-        string_stream << element->id() << ", ";
+        string_stream << element->id() << ",";
         traffic_light_map.at(line.id()).text += string_stream.str();
       }
     }


### PR DESCRIPTION
## Description

It was difficult to understand relationship between regulatry element id and road lanelet. In this PR, I fixed id visualization to show the id on stop line which is reffered by traffic regulatory element in order to make it easier to know related regulatory elements.

![image](https://github.com/autowarefoundation/autoware_common/assets/44889564/bba6a6dc-dfae-4d74-917b-71a92f73b993)
![image](https://github.com/autowarefoundation/autoware_common/assets/44889564/fc1471af-a61c-423d-bc2a-19477421b149)

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
