### PR TITLE
build: fix Boost UUID dependency

### DIFF
--- a/autoware_utils/package.xml
+++ b/autoware_utils/package.xml
@@ -11,6 +11,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>libboost-system-dev</depend>
   <depend>builtin_interfaces</depend>
   <depend>rclcpp</depend>
   <depend>unique_identifier_msgs</depend>

--- a/autoware_utils/package.xml
+++ b/autoware_utils/package.xml
@@ -11,8 +11,8 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-  <depend>libboost-system-dev</depend>
   <depend>builtin_interfaces</depend>
+  <depend>libboost-system-dev</depend>
   <depend>rclcpp</depend>
   <depend>unique_identifier_msgs</depend>
 


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
This PR adds a dependency for `libboost-system-dev` so that it can compile code that uses the Boost UUID library.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
