### PR TITLE
fix(lanelet2_extension): invalid access

### DIFF
--- a/tmp/lanelet2_extension/lib/utilities.cpp
+++ b/tmp/lanelet2_extension/lib/utilities.cpp
@@ -213,6 +213,9 @@ lanelet::LineString3d getLineStringFromArcLength(
   lanelet::Points3d points;
   double accumulated_length = 0;
   size_t start_index = linestring.size();
+  if (start_index == 0) {
+    return lanelet::LineString3d{lanelet::InvalId, points};
+  }
   for (size_t i = 0; i < linestring.size() - 1; i++) {
     const auto & p1 = linestring[i];
     const auto & p2 = linestring[i + 1];


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
This PR prevents `getLineStringFromArcLength` from SIGSEGV.
When `linestring.size()` is 0, `linestring.size() - 1` can be inf because`linestring.size()` is unsigned .

https://github.com/autowarefoundation/autoware_common/blob/0dbf93e79f886ab5f1a25e94e72d8b4605fd3f0b/tmp/lanelet2_extension/lib/utilities.cpp#L219

As a result, `linestring[i]` can be invalid access.
https://github.com/autowarefoundation/autoware_common/blob/0dbf93e79f886ab5f1a25e94e72d8b4605fd3f0b/tmp/lanelet2_extension/lib/utilities.cpp#L220 

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->
[TIER IV internal slack](https://star4.slack.com/archives/C0519A2HD1T/p1709277662657319)

## Tests performed

<!-- Describe how you have tested this PR. -->
We can reproduce this problem.
1. Download internal rosbag data.
[rosbag0](https://console.data-search.tier4.jp/projects/prd_jt/environments/393c3af9-bee1-42fc-85d7-f55f3d68a9e7/rosbags/c941b32d-538e-4c55-97ad-c39f9c661fb4)
[rosbag1](https://console.data-search.tier4.jp/projects/prd_jt/environments/393c3af9-bee1-42fc-85d7-f55f3d68a9e7/rosbags/c3b2ec48-146f-4417-867e-c4affcc93a11)
[rosbag2](https://console.data-search.tier4.jp/projects/prd_jt/environments/393c3af9-bee1-42fc-85d7-f55f3d68a9e7/rosbags/910d2ca6-ac69-4e62-bc20-4408964d88e5)
[rosbag3](https://console.data-search.tier4.jp/projects/prd_jt/environments/393c3af9-bee1-42fc-85d7-f55f3d68a9e7/rosbags/cf143a7c-2b9d-42d3-83fc-cd638c754d9a)
2. Prepare environment of pilo-auto.xx1:v0.43.6.0.
3. Execute `ros2 launch autoware_launch logging_simulator.launch.xml map_path:=$HOME/autoware_map/odaiba_beta vehicle_model:=jpntaxi sensor_model:=aip_xx1 localization:=false perception:=false`

4. After launching Step3, play the rosbag from 0 to 3 one by one with remmaping planning topic. 
`./play_bag_without_planning.sh <rosbag>`
```bash
#!/bin/bash
# play_bag_without_planning.sh

BAG_NAME=$1
PLANNING_TOPIC=$(ros2 bag info $BAG_NAME | awk '{print $2}' | grep planning | grep -v mission_planning)

COMMAND_OPTION='--remap '
for i in ${PLANNING_TOPIC[@]}; do
    TARGET_PLANNING_TOPIC=$i
    RENAMED_TARGET_PLANNING_TOPIC=$(echo $TARGET_PLANNING_TOPIC | sed 's/\/planning/\/tmp\/planning/g')
    COMMAND_OPTION=$COMMAND_OPTION' '$TARGET_PLANNING_TOPIC':='$RENAMED_TARGET_PLANNING_TOPIC
done

ros2 bag play $BAG_NAME $COMMAND_OPTION --clock  -s sqlite3
```

5. At the last time, there is SIGSEGV. Also I confirmed `linestring.size() - 1` is 18446744073709551615.

```
[component_container_mt-44] *** Aborted at 1709478740 (unix time) try "date -d @1709478740" if you are using GNU date ***
[component_container_mt-44] PC: @                0x0 (unknown)
[component_container_mt-44] *** SIGSEGV (@0x10) received by PID 315075 (TID 0x7f41daffd640) from PID 16; stack trace: ***
[component_container_mt-44]     @     0x7f41d805d046 (unknown)
[component_container_mt-44]     @     0x7f41f7842520 (unknown)
[component_container_mt-44]     @     0x7f41ec33aa6b lanelet::utils::(anonymous namespace)::getLineStringFromArcLength()
[component_container_mt-44]     @     0x7f41ec33ca73 lanelet::utils::getPolygonFromArcLength()
[component_container_mt-44]     @     0x7f41d9cd61fe behavior_path_planner::NormalLaneChange::getLaneChangePaths()
[component_container_mt-44]     @     0x7f41d9ccd39c behavior_path_planner::NormalLaneChange::getSafePath()
[component_container_mt-44]     @     0x7f41d9cccca9 behavior_path_planner::NormalLaneChange::updateLaneChangeStatus()
[component_container_mt-44]     @     0x7f41d9b23626 behavior_path_planner::PlannerManager::getRequestModules()
[component_container_mt-44]     @     0x7f41d9b29042 _ZZN21behavior_path_planner14PlannerManager3runERKSt10shared_ptrINS_11PlannerDataEEENKUlvE0_clEv
[component_container_mt-44]     @     0x7f41d9b2996c behavior_path_planner::PlannerManager::run()
[component_container_mt-44]     @     0x7f41d9b5d33b behavior_path_planner::BehaviorPathPlannerNode::run()
[component_container_mt-44]     @     0x7f41d9b65965 rclcpp::GenericTimer<>::execute_callback()
[component_container_mt-44]     @     0x7f41f815effe rclcpp::Executor::execute_any_executable()
[component_container_mt-44]     @     0x7f41f8165432 rclcpp::executors::MultiThreadedExecutor::run()
[component_container_mt-44]     @     0x7f41f7cdc253 (unknown)
[component_container_mt-44]     @     0x7f41f7894ac3 (unknown)
[component_container_mt-44]     @     0x7f41f7926850 (unknown)
[component_container_mt-44]     @                0x0 (unknown)
[component_container_mt-27] [ERROR] [1709478740.785274785] [pcl_ros]: Input dataset has no X-Y-Z coordinates! Cannot convert to Eigen format.
[ERROR] [component_container_mt-44]: process has died [pid 315075, exit code -11, cmd '/home/shmpwk/xx1/pilot-auto.xx1.v0.43.6.0/install/rclcpp_components/lib/rclcpp_components/component_container_mt --ros-args -r __node:=behavior_planning_container -r __ns:=/planning/scenario_planning/lane_driving/behavior_planning -p use_sim_time:=True -p wheel_radius:=0.31 -p wheel_width:=0.18 -p wheel_base:=2.75 -p wheel_tread:=1.485 -p front_overhang:=0.8 -p rear_overhang:=0.85 -p left_overhang:=0.105 -p right_overhang:=0.105 -p vehicle_height:=2.5 -p max_steer_angle:=0.55'].
```

With this PR, I confirmed there is no SIGSEGV.

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->
N/A

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->
N/A

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->
Fix bug

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
