### PR TITLE
fix: boost optional build error on rolling environment

### DIFF
--- a/tmp/lanelet2_extension/test/src/test_regulatory_elements.cpp
+++ b/tmp/lanelet2_extension/test/src/test_regulatory_elements.cpp
@@ -16,11 +16,12 @@
 
 #include "lanelet2_extension/regulatory_elements/autoware_traffic_light.hpp"
 
+#include <boost/optional/optional_io.hpp>
+
 #include <gtest/gtest.h>
 #include <lanelet2_core/Attribute.h>
 #include <lanelet2_core/LaneletMap.h>
 
-#include <boost/optional/optional_io.hpp>
 #include <cmath>
 #include <vector>
 

--- a/tmp/lanelet2_extension/test/src/test_regulatory_elements.cpp
+++ b/tmp/lanelet2_extension/test/src/test_regulatory_elements.cpp
@@ -20,6 +20,7 @@
 #include <lanelet2_core/Attribute.h>
 #include <lanelet2_core/LaneletMap.h>
 
+#include <boost/optional/optional_io.hpp>
 #include <cmath>
 #include <vector>
 


### PR DESCRIPTION
## Description

As ROS 2 jazzy will be released soon, this PR will fix build error found in rolling build environment.

- Add `boost/optional/optional_io.hpp` to some source files. This header file is required by newer version of Boost.

## Tests performed

`colcon test` on humble distribution does not show new error.

## Effects on system behavior

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
