### PR TITLE
chore(lanelet2_extension): add a not for the centerline overwriting

### DIFF
--- a/tmp/lanelet2_extension/lib/utilities.cpp
+++ b/tmp/lanelet2_extension/lib/utilities.cpp
@@ -506,6 +506,15 @@ void overwriteLaneletsCenterline(
   for (auto & lanelet_obj : lanelet_map->laneletLayer) {
     if (force_overwrite || !lanelet_obj.hasCustomCenterline()) {
       const auto fine_center_line = generateFineCenterline(lanelet_obj, resolution);
+
+      // TODO(someone): Ideally, the following code is required when writing a map after
+      //                this function is called. However, since the number of points' IDs
+      //                will increase a lot, the computation cost may increase as well.
+      //                We cannot estimate the impact, so we comment out the code for now.
+      // for (const auto & fine_center_point : fine_center_line) {
+      //   lanelet_map->add(static_cast<lanelet::Point3d>(fine_center_point));
+      // }
+      // lanelet_map->add(fine_center_line);
       lanelet_obj.setCenterline(fine_center_line);
     }
   }


### PR DESCRIPTION
## Description

Added a note for the concern about the overwriteLaneletsCenterline function.
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->
Nothing

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->
Nothing
## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
