### PR TITLE
perf(lanelet2_extension): use std::unordered_set<>::find instead of std::find

### DIFF
--- a/tmp/lanelet2_extension/lib/visualization.cpp
+++ b/tmp/lanelet2_extension/lib/visualization.cpp
@@ -40,7 +40,7 @@ namespace
 template <typename T>
 bool exists(const std::unordered_set<T> & set, const T & element)
 {
-  return std::find(set.begin(), set.end(), element) != set.end();
+  return set.find(element) != set.end();
 }
 
 void adjacentPoints(


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
use `std::unordered_set<>::find` instead of `std::find` to improve lookup speed.
See https://stackoverflow.com/questions/71062930/how-does-stdfind-works-with-stdset

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
