### PR TITLE
perf(lanelet2_extension): more efficient getLinkedParkingLot

### DIFF
--- a/tmp/lanelet2_extension/include/lanelet2_extension/utility/query.hpp
+++ b/tmp/lanelet2_extension/include/lanelet2_extension/utility/query.hpp
@@ -189,7 +189,7 @@ bool getLinkedParkingLot(
   lanelet::ConstPolygon3d * linked_parking_lot);
 // get linked parking lot from current pose of ego car
 bool getLinkedParkingLot(
-  const lanelet::BasicPoint2d & current_position, const lanelet::ConstPolygons3d & all_parking_lots,
+  const lanelet::BasicPoint2d & current_position, const lanelet::LaneletMapPtr & lanelet_map_ptr,
   lanelet::ConstPolygon3d * linked_parking_lot);
 // get linked parking lot from parking space
 bool getLinkedParkingLot(

--- a/tmp/lanelet2_extension/lib/query.cpp
+++ b/tmp/lanelet2_extension/lib/query.cpp
@@ -591,15 +591,20 @@ bool query::getLinkedParkingLot(
 
 // get overlapping parking lot
 bool query::getLinkedParkingLot(
-  const lanelet::BasicPoint2d & current_position, const lanelet::ConstPolygons3d & all_parking_lots,
+  const lanelet::BasicPoint2d & current_position, const lanelet::LaneletMapPtr & lanelet_map_ptr,
   lanelet::ConstPolygon3d * linked_parking_lot)
 {
-  for (const auto & parking_lot : all_parking_lots) {
-    const double distance =
-      boost::geometry::distance(current_position, to2D(parking_lot).basicPolygon());
-    if (distance < std::numeric_limits<double>::epsilon()) {
-      *linked_parking_lot = parking_lot;
-      return true;
+  const auto candidates =
+    lanelet_map_ptr->polygonLayer.search(lanelet::geometry::boundingBox2d(current_position));
+  for (const auto & candidate : candidates) {
+    const std::string type = candidate.attributeOr(lanelet::AttributeName::Type, "none");
+    if (type == "parking_lot") {
+      const double distance =
+        boost::geometry::distance(current_position, to2D(candidate).basicPolygon());
+      if (distance < std::numeric_limits<double>::epsilon()) {
+        *linked_parking_lot = candidate;
+        return true;
+      }
     }
   }
   return false;

--- a/tmp/lanelet2_extension_python/src/utility.cpp
+++ b/tmp/lanelet2_extension_python/src/utility.cpp
@@ -209,11 +209,11 @@ lanelet::Optional<lanelet::ConstPolygon3d> getLinkedParkingLot(
 }
 
 lanelet::Optional<lanelet::ConstPolygon3d> getLinkedParkingLot(
-  const lanelet::BasicPoint2d & current_position, const lanelet::ConstPolygons3d & all_parking_lots)
+  const lanelet::BasicPoint2d & current_position, const lanelet::LaneletMapPtr lanelet_map_ptr)
 {
   lanelet::ConstPolygon3d linked_parking_lot;
   if (lanelet::utils::query::getLinkedParkingLot(
-        current_position, all_parking_lots, &linked_parking_lot)) {
+        current_position, lanelet_map_ptr, &linked_parking_lot)) {
     return linked_parking_lot;
   } else {
     return {};
@@ -506,7 +506,7 @@ BOOST_PYTHON_MODULE(_lanelet2_extension_python_boost_python_utility)
     const lanelet::ConstLanelet &, const lanelet::ConstPolygons3d &)>(
     "getLinkedParkingLot", ::getLinkedParkingLot);
   bp::def<lanelet::Optional<lanelet::ConstPolygon3d>(
-    const lanelet::BasicPoint2d &, const lanelet::ConstPolygons3d &)>(
+    const lanelet::BasicPoint2d &, const lanelet::LaneletMapPtr)>(
     "getLinkedParkingLot", ::getLinkedParkingLot);
   bp::def<lanelet::Optional<lanelet::ConstPolygon3d>(
     const lanelet::ConstLineString3d &, const lanelet::ConstPolygons3d &)>(


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Improve the `getLinkedParkingLot()` function so that it does not requiring providing ALL parking lots lanelets.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
