### PR TITLE
ci: overhaul build-and-test derivatives and split clang-tidy

### DIFF
--- a/.github/workflows/build-and-test-arm64.yaml
+++ b/.github/workflows/build-and-test-arm64.yaml
@@ -53,12 +53,12 @@ jobs:
 
       - name: Upload coverage to CodeCov
         if: ${{ steps.test.outputs.coverage-report-files != '' }}
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           files: ${{ steps.test.outputs.coverage-report-files }}
           fail_ci_if_error: false
           verbose: true
-          flags: total
+          flags: total-arm64
 
       - name: Show disk space after the tasks
         run: df -h

--- a/.github/workflows/build-and-test-arm64.yaml
+++ b/.github/workflows/build-and-test-arm64.yaml
@@ -1,4 +1,4 @@
-name: build-and-test-self-hosted
+name: build-and-test-arm64
 
 on:
   schedule:
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-and-test-self-hosted:
+  build-and-test-arm64:
     runs-on: [self-hosted, linux, ARM64]
     container: ${{ matrix.container }}
     strategy:
@@ -20,7 +20,12 @@ jobs:
             build-depends-repos: build_depends.repos
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Show disk space before the tasks
+        run: df -h
 
       - name: Remove exec_depend
         uses: autowarefoundation/autoware-github-actions/remove-exec-depend@v1
@@ -39,8 +44,21 @@ jobs:
 
       - name: Test
         if: ${{ steps.get-self-packages.outputs.self-packages != '' }}
+        id: test
         uses: autowarefoundation/autoware-github-actions/colcon-test@v1
         with:
           rosdistro: ${{ matrix.rosdistro }}
           target-packages: ${{ steps.get-self-packages.outputs.self-packages }}
           build-depends-repos: ${{ matrix.build-depends-repos }}
+
+      - name: Upload coverage to CodeCov
+        if: ${{ steps.test.outputs.coverage-report-files != '' }}
+        uses: codecov/codecov-action@v3
+        with:
+          files: ${{ steps.test.outputs.coverage-report-files }}
+          fail_ci_if_error: false
+          verbose: true
+          flags: total
+
+      - name: Show disk space after the tasks
+        run: df -h

--- a/.github/workflows/build-and-test-differential-arm64.yaml
+++ b/.github/workflows/build-and-test-differential-arm64.yaml
@@ -66,12 +66,12 @@ jobs:
 
       - name: Upload coverage to CodeCov
         if: ${{ steps.test.outputs.coverage-report-files != '' }}
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           files: ${{ steps.test.outputs.coverage-report-files }}
           fail_ci_if_error: false
           verbose: true
-          flags: differential
+          flags: differential-arm64
 
       - name: Show disk space after the tasks
         run: df -h

--- a/.github/workflows/build-and-test-differential-arm64.yaml
+++ b/.github/workflows/build-and-test-differential-arm64.yaml
@@ -1,24 +1,23 @@
-name: build-and-test-differential-self-hosted
+name: build-and-test-differential-arm64
 
 on:
   pull_request:
     types:
       - opened
       - synchronize
+      - reopened
       - labeled
-  workflow_dispatch:
 
 jobs:
-  prevent-no-label-execution:
-    uses: autowarefoundation/autoware-github-actions/.github/workflows/prevent-no-label-execution.yaml@v1
+  make-sure-label-is-present:
+    uses: autowarefoundation/autoware-github-actions/.github/workflows/make-sure-label-is-present.yaml@v1
     with:
-      label: ARM64
+      label: type:arm64
 
-  build-and-test-differential-self-hosted:
-    needs: prevent-no-label-execution
-    if: ${{ needs.prevent-no-label-execution.outputs.run == 'true' }}
+  build-and-test-differential-arm64:
+    needs: make-sure-label-is-present
+    if: ${{ needs.make-sure-label-is-present.outputs.result == 'true' }}
     runs-on: [self-hosted, linux, ARM64]
-    container: ${{ matrix.container }}
     strategy:
       fail-fast: false
       matrix:
@@ -29,10 +28,17 @@ jobs:
             container: ros:humble
             build-depends-repos: build_depends.repos
     steps:
-      - name: Check out repository
-        uses: actions/checkout@v3
+      - name: Set PR fetch depth
+        run: echo "PR_FETCH_DEPTH=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> "${GITHUB_ENV}"
+
+      - name: Checkout PR branch and all PR commits
+        uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: ${{ env.PR_FETCH_DEPTH }}
+
+      - name: Show disk space before the tasks
+        run: df -h
 
       - name: Remove exec_depend
         uses: autowarefoundation/autoware-github-actions/remove-exec-depend@v1
@@ -50,9 +56,22 @@ jobs:
           build-depends-repos: ${{ matrix.build-depends-repos }}
 
       - name: Test
+        id: test
         if: ${{ steps.get-modified-packages.outputs.modified-packages != '' }}
         uses: autowarefoundation/autoware-github-actions/colcon-test@v1
         with:
           rosdistro: ${{ matrix.rosdistro }}
           target-packages: ${{ steps.get-modified-packages.outputs.modified-packages }}
           build-depends-repos: ${{ matrix.build-depends-repos }}
+
+      - name: Upload coverage to CodeCov
+        if: ${{ steps.test.outputs.coverage-report-files != '' }}
+        uses: codecov/codecov-action@v3
+        with:
+          files: ${{ steps.test.outputs.coverage-report-files }}
+          fail_ci_if_error: false
+          verbose: true
+          flags: differential
+
+      - name: Show disk space after the tasks
+        run: df -h

--- a/.github/workflows/build-and-test-differential-arm64.yaml
+++ b/.github/workflows/build-and-test-differential-arm64.yaml
@@ -18,6 +18,7 @@ jobs:
     needs: make-sure-label-is-present
     if: ${{ needs.make-sure-label-is-present.outputs.result == 'true' }}
     runs-on: [self-hosted, linux, ARM64]
+    container: ${{ matrix.container }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build-and-test-differential.yaml
+++ b/.github/workflows/build-and-test-differential.yaml
@@ -2,11 +2,22 @@ name: build-and-test-differential
 
 on:
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
 
 jobs:
+  make-sure-label-is-present:
+    uses: autowarefoundation/autoware-github-actions/.github/workflows/make-sure-label-is-present.yaml@v1
+    with:
+      label: tag:run-build-and-test-differential
+
   build-and-test-differential:
+    needs: make-sure-label-is-present
+    if: ${{ needs.make-sure-label-is-present.outputs.result == 'true' }}
     runs-on: ubuntu-latest
-    container: ${{ matrix.container }}
     strategy:
       fail-fast: false
       matrix:
@@ -17,10 +28,17 @@ jobs:
             container: ros:humble
             build-depends-repos: build_depends.repos
     steps:
-      - name: Check out repository
-        uses: actions/checkout@v3
+      - name: Set PR fetch depth
+        run: echo "PR_FETCH_DEPTH=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> "${GITHUB_ENV}"
+
+      - name: Checkout PR branch and all PR commits
+        uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: ${{ env.PR_FETCH_DEPTH }}
+
+      - name: Show disk space before the tasks
+        run: df -h
 
       - name: Remove exec_depend
         uses: autowarefoundation/autoware-github-actions/remove-exec-depend@v1
@@ -55,37 +73,5 @@ jobs:
           verbose: true
           flags: differential
 
-  clang-tidy-differential:
-    runs-on: ubuntu-latest
-    container: ros:humble
-    needs: build-and-test-differential
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Remove exec_depend
-        uses: autowarefoundation/autoware-github-actions/remove-exec-depend@v1
-
-      - name: Get modified packages
-        id: get-modified-packages
-        uses: autowarefoundation/autoware-github-actions/get-modified-packages@v1
-
-      - name: Get modified files
-        id: get-modified-files
-        uses: tj-actions/changed-files@v42
-        with:
-          files: |
-            **/*.cpp
-            **/*.hpp
-
-      - name: Run clang-tidy
-        if: ${{ steps.get-modified-files.outputs.all_changed_files != '' }}
-        uses: autowarefoundation/autoware-github-actions/clang-tidy@v1
-        with:
-          rosdistro: humble
-          target-packages: ${{ steps.get-modified-packages.outputs.modified-packages }}
-          target-files: ${{ steps.get-modified-files.outputs.all_changed_files }}
-          clang-tidy-config-url: https://raw.githubusercontent.com/autowarefoundation/autoware/main/.clang-tidy
-          build-depends-repos: build_depends.repos
+      - name: Show disk space after the tasks
+        run: df -h

--- a/.github/workflows/build-and-test-differential.yaml
+++ b/.github/workflows/build-and-test-differential.yaml
@@ -18,6 +18,7 @@ jobs:
     needs: make-sure-label-is-present
     if: ${{ needs.make-sure-label-is-present.outputs.result == 'true' }}
     runs-on: ubuntu-latest
+    container: ${{ matrix.container }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -22,15 +22,12 @@ jobs:
             build-depends-repos: build_depends.repos
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
-
-      - name: Free disk space (Ubuntu)
-        uses: jlumbroso/free-disk-space@v1.3.1
+        uses: actions/checkout@v4
         with:
-          tool-cache: false
-          dotnet: false
-          swap-storage: false
-          large-packages: false
+          fetch-depth: 1
+
+      - name: Show disk space before the tasks
+        run: df -h
 
       - name: Remove exec_depend
         uses: autowarefoundation/autoware-github-actions/remove-exec-depend@v1

--- a/.github/workflows/clang-tidy-differential.yaml
+++ b/.github/workflows/clang-tidy-differential.yaml
@@ -1,0 +1,61 @@
+name: clang-tidy-differential
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+
+jobs:
+  make-sure-label-is-present:
+    uses: autowarefoundation/autoware-github-actions/.github/workflows/make-sure-label-is-present.yaml@v1
+    with:
+      label: tag:run-clang-tidy-differential
+
+  clang-tidy-differential:
+    needs: make-sure-label-is-present
+    if: ${{ needs.make-sure-label-is-present.outputs.result == 'true' }}
+    runs-on: ubuntu-latest
+    container: ros:humble
+    steps:
+      - name: Set PR fetch depth
+        run: echo "PR_FETCH_DEPTH=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> "${GITHUB_ENV}"
+
+      - name: Checkout PR branch and all PR commits
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: ${{ env.PR_FETCH_DEPTH }}
+
+      - name: Show disk space before the tasks
+        run: df -h
+
+      - name: Remove exec_depend
+        uses: autowarefoundation/autoware-github-actions/remove-exec-depend@v1
+
+      - name: Get modified packages
+        id: get-modified-packages
+        uses: autowarefoundation/autoware-github-actions/get-modified-packages@v1
+
+      - name: Get modified files
+        id: get-modified-files
+        uses: tj-actions/changed-files@v42
+        with:
+          files: |
+            **/*.cpp
+            **/*.hpp
+
+      - name: Run clang-tidy
+        if: ${{ steps.get-modified-files.outputs.all_changed_files != '' }}
+        uses: autowarefoundation/autoware-github-actions/clang-tidy@v1
+        with:
+          rosdistro: humble
+          target-packages: ${{ steps.get-modified-packages.outputs.modified-packages }}
+          target-files: ${{ steps.get-modified-files.outputs.all_changed_files }}
+          clang-tidy-config-url: https://raw.githubusercontent.com/autowarefoundation/autoware/main/.clang-tidy
+          build-depends-repos: build_depends.repos
+
+      - name: Show disk space after the tasks
+        run: df -h


### PR DESCRIPTION
## Description

- Split clang-tidy into its own workflow
- Rename `-self-hosted` jobs to `-arm64`
- Remove `jlumbroso/free-disk-space@v1.3.1` because it has no effect in containers.
- Upgrade `actions/checkout@v3` to `v4`
- Run `-differential` jobs on `reopened` too.

### Tag dependency changes

- Add tag dependency to both `build-and-main-differential` and `clang-tidy-differential` workflows.
- Make use of `make-sure-label-is-present.yaml` reusable workflow since it supports multiple labels.
   - See: https://github.com/autowarefoundation/autoware-github-actions/pull/301

### Fetch depth changes

- For `build-and-main` jobs:
   - add `fetch-depth: 1` since they don't check for modified packages
- For `build-and-main-differential` jobs:
   - add `Set PR fetch depth` step to fetch only the PR commits.

## Tests performed

All the differential jobs are tested with the labels and passed on this PR.

- `build-and-test` on main has passed: https://github.com/autowarefoundation/autoware_common/actions/runs/9514721439
- `build-and-test-arm64` cannot be tested before merging for the first time but will probably pass.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
