### PR TITLE
feat(lanelet2_extension): overwriteLaneletsCenterline supports "waypoints"

### DIFF
--- a/tmp/lanelet2_extension/docs/lanelet2_format_extension.md
+++ b/tmp/lanelet2_extension/docs/lanelet2_format_extension.md
@@ -479,3 +479,23 @@ _An example:_
 ...
 
 ```
+
+### Centerline
+
+Note that the following explanation is not related to the Lanelet2 map format but how the Autoware handles the centerline in the Lanelet2 map.
+
+Centerline is defined in Lanelet2 to guide the vehicle. By explicitly setting the centerline in the Lanelet2 map, the ego's planned path follows the centerline.
+However, based on the current Autoware's usage of the centerline, there are several limitations.
+
+- The object's predicted path also follows the centerline.
+  - This may adversely affect the decision making of planning modules since the centerline is supposed to be used only by the ego's path planning.
+- The coordinate transformation on the lane's frenet frame cannot be calculated correctly.
+  - For example, when the lateral distance between the actual road's centerline and a parked vehicle is calculated, actually the result will be the lateral distance between the (explicit) centerline and the vehicle.
+
+To solve above limitations, the `overwriteLaneletsCenterline` has a `use_waypoints` flag where the centerline in all the lanes is calculated.
+
+- `use_waypoints` is True
+  - The (explicit) centerline in the Lanelet2 map is converted to the new `waypoints` tag. This `waypoints` is only applied to the ego's path planning.
+  - Therefore, the above limitations can be solved, but the Autoware's usage of the centerline may be hard to understand.
+- `use_waypoints` is False
+  - The (explicit) centerline in the Lanelet2 map is used as it is. Easy to understand the Autoware's usage of the centerline, but we still have above limitations.

--- a/tmp/lanelet2_extension/docs/lanelet2_format_extension.md
+++ b/tmp/lanelet2_extension/docs/lanelet2_format_extension.md
@@ -492,10 +492,10 @@ However, based on the current Autoware's usage of the centerline, there are seve
 - The coordinate transformation on the lane's frenet frame cannot be calculated correctly.
   - For example, when the lateral distance between the actual road's centerline and a parked vehicle is calculated, actually the result will be the lateral distance between the (explicit) centerline and the vehicle.
 
-To solve above limitations, the `overwriteLaneletsCenterline` has a `use_waypoints` flag where the centerline in all the lanes is calculated.
+To solve above limitations, the `overwriteLaneletsCenterlineWithWaypoints` was implemented in addition to `overwriteLaneletsCenterline` where the centerline in all the lanes is calculated.
 
-- `use_waypoints` is True
+- `overwriteLaneletsCenterlineWithWaypoints`
   - The (explicit) centerline in the Lanelet2 map is converted to the new `waypoints` tag. This `waypoints` is only applied to the ego's path planning.
   - Therefore, the above limitations can be solved, but the Autoware's usage of the centerline may be hard to understand.
-- `use_waypoints` is False
+- `overwriteLaneletsCenterline`
   - The (explicit) centerline in the Lanelet2 map is used as it is. Easy to understand the Autoware's usage of the centerline, but we still have above limitations.

--- a/tmp/lanelet2_extension/include/lanelet2_extension/utility/utilities.hpp
+++ b/tmp/lanelet2_extension/include/lanelet2_extension/utility/utilities.hpp
@@ -56,7 +56,7 @@ lanelet::ConstLanelets getExpandedLanelets(
  * doesn't have enough quality
  */
 void overwriteLaneletsCenterline(
-  lanelet::LaneletMapPtr lanelet_map, const double resolution = 5.0,
+  lanelet::LaneletMapPtr lanelet_map, const double resolution, const bool use_waypoints,
   const bool force_overwrite = false);
 
 lanelet::ConstLanelets getConflictingLanelets(

--- a/tmp/lanelet2_extension/include/lanelet2_extension/utility/utilities.hpp
+++ b/tmp/lanelet2_extension/include/lanelet2_extension/utility/utilities.hpp
@@ -56,7 +56,17 @@ lanelet::ConstLanelets getExpandedLanelets(
  * doesn't have enough quality
  */
 void overwriteLaneletsCenterline(
-  lanelet::LaneletMapPtr lanelet_map, const double resolution, const bool use_waypoints,
+  lanelet::LaneletMapPtr lanelet_map, const double resolution = 5.0,
+  const bool force_overwrite = false);
+
+/**
+ * @brief  Apply another patch for centerline because the overwriteLaneletsCenterline
+ * has several limitations. See the following document in detail.
+ * https://github.com/autowarefoundation/autoware_common/blob/main/tmp/lanelet2_extension/docs/lanelet2_format_extension.md#centerline
+ * // NOLINT
+ */
+void overwriteLaneletsCenterlineWithWaypoints(
+  lanelet::LaneletMapPtr lanelet_map, const double resolution = 5.0,
   const bool force_overwrite = false);
 
 lanelet::ConstLanelets getConflictingLanelets(

--- a/tmp/lanelet2_extension/lib/utilities.cpp
+++ b/tmp/lanelet2_extension/lib/utilities.cpp
@@ -501,12 +501,28 @@ lanelet::ConstLanelets getExpandedLanelets(
 }
 
 void overwriteLaneletsCenterline(
-  lanelet::LaneletMapPtr lanelet_map, const double resolution, const bool force_overwrite)
+  lanelet::LaneletMapPtr lanelet_map, const double resolution, const bool use_waypoints,
+  const bool force_overwrite)
 {
   for (auto & lanelet_obj : lanelet_map->laneletLayer) {
-    if (force_overwrite || !lanelet_obj.hasCustomCenterline()) {
+    if (force_overwrite) {
       const auto fine_center_line = generateFineCenterline(lanelet_obj, resolution);
       lanelet_obj.setCenterline(fine_center_line);
+    } else {
+      if (use_waypoints) {
+        if (lanelet_obj.hasCustomCenterline()) {
+          const auto & centerline = lanelet_obj.centerline();
+          lanelet_obj.setAttribute("waypoints", centerline.id());
+        }
+
+        const auto fine_center_line = generateFineCenterline(lanelet_obj, resolution);
+        lanelet_obj.setCenterline(fine_center_line);
+      } else {
+        if (!lanelet_obj.hasCustomCenterline()) {
+          const auto fine_center_line = generateFineCenterline(lanelet_obj, resolution);
+          lanelet_obj.setCenterline(fine_center_line);
+        }
+      }
     }
   }
 }

--- a/tmp/lanelet2_extension/lib/utilities.cpp
+++ b/tmp/lanelet2_extension/lib/utilities.cpp
@@ -508,21 +508,20 @@ void overwriteLaneletsCenterline(
     if (force_overwrite) {
       const auto fine_center_line = generateFineCenterline(lanelet_obj, resolution);
       lanelet_obj.setCenterline(fine_center_line);
-    } else {
-      if (use_waypoints) {
-        if (lanelet_obj.hasCustomCenterline()) {
-          const auto & centerline = lanelet_obj.centerline();
-          lanelet_obj.setAttribute("waypoints", centerline.id());
-        }
-
-        const auto fine_center_line = generateFineCenterline(lanelet_obj, resolution);
-        lanelet_obj.setCenterline(fine_center_line);
-      } else {
-        if (!lanelet_obj.hasCustomCenterline()) {
-          const auto fine_center_line = generateFineCenterline(lanelet_obj, resolution);
-          lanelet_obj.setCenterline(fine_center_line);
-        }
+    if (force_overwrite) {
+      const auto fine_center_line = generateFineCenterline(lanelet_obj, resolution);
+      lanelet_obj.setCenterline(fine_center_line);
+    } else if (use_waypoints) {
+      if (lanelet_obj.hasCustomCenterline()) {
+        const auto & centerline = lanelet_obj.centerline();
+        lanelet_obj.setAttribute("waypoints", centerline.id());
       }
+
+      const auto fine_center_line = generateFineCenterline(lanelet_obj, resolution);
+      lanelet_obj.setCenterline(fine_center_line);
+    } else if (!lanelet_obj.hasCustomCenterline()) {
+      const auto fine_center_line = generateFineCenterline(lanelet_obj, resolution);
+      lanelet_obj.setCenterline(fine_center_line);
     }
   }
 }

--- a/tmp/lanelet2_extension/lib/utilities.cpp
+++ b/tmp/lanelet2_extension/lib/utilities.cpp
@@ -508,303 +508,303 @@ void overwriteLaneletsCenterline(
     if (force_overwrite) {
       const auto fine_center_line = generateFineCenterline(lanelet_obj, resolution);
       lanelet_obj.setCenterline(fine_center_line);
-    if (force_overwrite) {
-      const auto fine_center_line = generateFineCenterline(lanelet_obj, resolution);
-      lanelet_obj.setCenterline(fine_center_line);
-    } else if (use_waypoints) {
-      if (lanelet_obj.hasCustomCenterline()) {
-        const auto & centerline = lanelet_obj.centerline();
-        lanelet_obj.setAttribute("waypoints", centerline.id());
+      if (force_overwrite) {
+        const auto fine_center_line = generateFineCenterline(lanelet_obj, resolution);
+        lanelet_obj.setCenterline(fine_center_line);
+      } else if (use_waypoints) {
+        if (lanelet_obj.hasCustomCenterline()) {
+          const auto & centerline = lanelet_obj.centerline();
+          lanelet_obj.setAttribute("waypoints", centerline.id());
+        }
+
+        const auto fine_center_line = generateFineCenterline(lanelet_obj, resolution);
+        lanelet_obj.setCenterline(fine_center_line);
+      } else if (!lanelet_obj.hasCustomCenterline()) {
+        const auto fine_center_line = generateFineCenterline(lanelet_obj, resolution);
+        lanelet_obj.setCenterline(fine_center_line);
       }
-
-      const auto fine_center_line = generateFineCenterline(lanelet_obj, resolution);
-      lanelet_obj.setCenterline(fine_center_line);
-    } else if (!lanelet_obj.hasCustomCenterline()) {
-      const auto fine_center_line = generateFineCenterline(lanelet_obj, resolution);
-      lanelet_obj.setCenterline(fine_center_line);
     }
   }
-}
 
-lanelet::ConstLanelets getConflictingLanelets(
-  const lanelet::routing::RoutingGraphConstPtr & graph, const lanelet::ConstLanelet & lanelet)
-{
-  const auto & llt_or_areas = graph->conflicting(lanelet);
-  lanelet::ConstLanelets lanelets;
-  lanelets.reserve(llt_or_areas.size());
-  for (const auto & l_or_a : llt_or_areas) {
-    auto llt_opt = l_or_a.lanelet();
-    if (!!llt_opt) {
-      lanelets.push_back(llt_opt.get());
+  lanelet::ConstLanelets getConflictingLanelets(
+    const lanelet::routing::RoutingGraphConstPtr & graph, const lanelet::ConstLanelet & lanelet)
+  {
+    const auto & llt_or_areas = graph->conflicting(lanelet);
+    lanelet::ConstLanelets lanelets;
+    lanelets.reserve(llt_or_areas.size());
+    for (const auto & l_or_a : llt_or_areas) {
+      auto llt_opt = l_or_a.lanelet();
+      if (!!llt_opt) {
+        lanelets.push_back(llt_opt.get());
+      }
     }
-  }
-  return lanelets;
-}
-
-bool lineStringWithWidthToPolygon(
-  const lanelet::ConstLineString3d & linestring, lanelet::ConstPolygon3d * polygon)
-{
-  if (polygon == nullptr) {
-    std::cerr << __func__ << ": polygon is null pointer! Failed to convert to polygon."
-              << std::endl;
-    return false;
-  }
-  if (linestring.size() != 2) {
-    std::cerr << __func__ << ": linestring" << linestring.id() << " must have 2 points! ("
-              << linestring.size() << " != 2)" << std::endl
-              << "Failed to convert to polygon.";
-    return false;
-  }
-  if (!linestring.hasAttribute("width")) {
-    std::cerr << __func__ << ": linestring" << linestring.id()
-              << " does not have width tag. Failed to convert to polygon.";
-    return false;
+    return lanelets;
   }
 
-  const Eigen::Vector3d direction =
-    linestring.back().basicPoint() - linestring.front().basicPoint();
-  const double width = linestring.attributeOr("width", 0.0);
-  const Eigen::Vector3d direction_left =
-    (Eigen::AngleAxisd(M_PI_2, Eigen::Vector3d::UnitZ()) * direction).normalized();
-
-  const Eigen::Vector3d eigen_p1 = linestring.front().basicPoint() + direction_left * width / 2;
-  const Eigen::Vector3d eigen_p2 = linestring.back().basicPoint() + direction_left * width / 2;
-  const Eigen::Vector3d eigen_p3 = linestring.back().basicPoint() - direction_left * width / 2;
-  const Eigen::Vector3d eigen_p4 = linestring.front().basicPoint() - direction_left * width / 2;
-
-  const lanelet::Point3d p1(lanelet::InvalId, eigen_p1.x(), eigen_p1.y(), eigen_p1.z());
-  const lanelet::Point3d p2(lanelet::InvalId, eigen_p2.x(), eigen_p2.y(), eigen_p2.z());
-  const lanelet::Point3d p3(lanelet::InvalId, eigen_p3.x(), eigen_p3.y(), eigen_p3.z());
-  const lanelet::Point3d p4(lanelet::InvalId, eigen_p4.x(), eigen_p4.y(), eigen_p4.z());
-
-  *polygon = lanelet::Polygon3d(lanelet::InvalId, {p1, p2, p3, p4});
-
-  return true;
-}
-
-bool lineStringToPolygon(
-  const lanelet::ConstLineString3d & linestring, lanelet::ConstPolygon3d * polygon)
-{
-  if (polygon == nullptr) {
-    RCLCPP_ERROR_STREAM(
-      rclcpp::get_logger("lanelet2_extension.visualization"),
-      __func__ << ": polygon is null pointer! Failed to convert to polygon.");
-    return false;
-  }
-  if (linestring.size() < 4) {
-    if (linestring.size() < 3 || linestring.front().id() == linestring.back().id()) {
-      RCLCPP_WARN_STREAM(
-        rclcpp::get_logger("lanelet2_extension.visualization"),
-        __func__ << ": linestring" << linestring.id()
-                 << " must have more than different 3 points! (size is " << linestring.size()
-                 << "). Failed to convert to polygon.");
+  bool lineStringWithWidthToPolygon(
+    const lanelet::ConstLineString3d & linestring, lanelet::ConstPolygon3d * polygon)
+  {
+    if (polygon == nullptr) {
+      std::cerr << __func__ << ": polygon is null pointer! Failed to convert to polygon."
+                << std::endl;
       return false;
     }
-  }
-
-  lanelet::Polygon3d llt_poly;
-
-  for (const auto & lp : linestring) {
-    llt_poly.push_back(lanelet::Point3d(
-      lanelet::InvalId, lp.basicPoint().x(), lp.basicPoint().y(), lp.basicPoint().z()));
-  }
-
-  if (linestring.front().id() == linestring.back().id()) {
-    llt_poly.pop_back();
-  }
-
-  *polygon = llt_poly;
-
-  return true;
-}
-
-double getLaneletLength2d(const lanelet::ConstLanelet & lanelet)
-{
-  return static_cast<double>(
-    boost::geometry::length(lanelet::utils::to2D(lanelet.centerline()).basicLineString()));
-}
-
-double getLaneletLength3d(const lanelet::ConstLanelet & lanelet)
-{
-  return static_cast<double>(boost::geometry::length(lanelet.centerline().basicLineString()));
-}
-
-double getLaneletLength2d(const lanelet::ConstLanelets & lanelet_sequence)
-{
-  double length = 0;
-  for (const auto & llt : lanelet_sequence) {
-    length += getLaneletLength2d(llt);
-  }
-  return length;
-}
-
-double getLaneletLength3d(const lanelet::ConstLanelets & lanelet_sequence)
-{
-  double length = 0;
-  for (const auto & llt : lanelet_sequence) {
-    length += getLaneletLength3d(llt);
-  }
-  return length;
-}
-
-lanelet::ArcCoordinates getArcCoordinates(
-  const lanelet::ConstLanelets & lanelet_sequence, const geometry_msgs::msg::Pose & pose)
-{
-  lanelet::ConstLanelet closest_lanelet;
-  lanelet::utils::query::getClosestLanelet(lanelet_sequence, pose, &closest_lanelet);
-
-  double length = 0;
-  lanelet::ArcCoordinates arc_coordinates;
-  for (const auto & llt : lanelet_sequence) {
-    const auto & centerline_2d = lanelet::utils::to2D(llt.centerline());
-    if (llt == closest_lanelet) {
-      const auto lanelet_point = lanelet::utils::conversion::toLaneletPoint(pose.position);
-      arc_coordinates = lanelet::geometry::toArcCoordinates(
-        centerline_2d, lanelet::utils::to2D(lanelet_point).basicPoint());
-      arc_coordinates.length += length;
-      break;
+    if (linestring.size() != 2) {
+      std::cerr << __func__ << ": linestring" << linestring.id() << " must have 2 points! ("
+                << linestring.size() << " != 2)" << std::endl
+                << "Failed to convert to polygon.";
+      return false;
     }
-    length += static_cast<double>(boost::geometry::length(centerline_2d));
-  }
-  return arc_coordinates;
-}
-
-lanelet::ConstLineString3d getClosestSegment(
-  const lanelet::BasicPoint2d & search_pt, const lanelet::ConstLineString3d & linestring)
-{
-  if (linestring.size() < 2) {
-    return lanelet::LineString3d();
-  }
-
-  lanelet::ConstLineString3d closest_segment;
-  double min_distance = std::numeric_limits<double>::max();
-
-  for (size_t i = 1; i < linestring.size(); i++) {
-    lanelet::BasicPoint3d prev_basic_pt = linestring[i - 1].basicPoint();
-    lanelet::BasicPoint3d current_basic_pt = linestring[i].basicPoint();
-
-    lanelet::Point3d prev_pt(
-      lanelet::InvalId, prev_basic_pt.x(), prev_basic_pt.y(), prev_basic_pt.z());
-    lanelet::Point3d current_pt(
-      lanelet::InvalId, current_basic_pt.x(), current_basic_pt.y(), current_basic_pt.z());
-
-    lanelet::LineString3d current_segment(lanelet::InvalId, {prev_pt, current_pt});
-    double distance = lanelet::geometry::distance2d(
-      lanelet::utils::to2D(current_segment).basicLineString(), search_pt);
-    if (distance < min_distance) {
-      closest_segment = current_segment;
-      min_distance = distance;
+    if (!linestring.hasAttribute("width")) {
+      std::cerr << __func__ << ": linestring" << linestring.id()
+                << " does not have width tag. Failed to convert to polygon.";
+      return false;
     }
+
+    const Eigen::Vector3d direction =
+      linestring.back().basicPoint() - linestring.front().basicPoint();
+    const double width = linestring.attributeOr("width", 0.0);
+    const Eigen::Vector3d direction_left =
+      (Eigen::AngleAxisd(M_PI_2, Eigen::Vector3d::UnitZ()) * direction).normalized();
+
+    const Eigen::Vector3d eigen_p1 = linestring.front().basicPoint() + direction_left * width / 2;
+    const Eigen::Vector3d eigen_p2 = linestring.back().basicPoint() + direction_left * width / 2;
+    const Eigen::Vector3d eigen_p3 = linestring.back().basicPoint() - direction_left * width / 2;
+    const Eigen::Vector3d eigen_p4 = linestring.front().basicPoint() - direction_left * width / 2;
+
+    const lanelet::Point3d p1(lanelet::InvalId, eigen_p1.x(), eigen_p1.y(), eigen_p1.z());
+    const lanelet::Point3d p2(lanelet::InvalId, eigen_p2.x(), eigen_p2.y(), eigen_p2.z());
+    const lanelet::Point3d p3(lanelet::InvalId, eigen_p3.x(), eigen_p3.y(), eigen_p3.z());
+    const lanelet::Point3d p4(lanelet::InvalId, eigen_p4.x(), eigen_p4.y(), eigen_p4.z());
+
+    *polygon = lanelet::Polygon3d(lanelet::InvalId, {p1, p2, p3, p4});
+
+    return true;
   }
-  return closest_segment;
-}
 
-lanelet::CompoundPolygon3d getPolygonFromArcLength(
-  const lanelet::ConstLanelets & lanelets, const double s1, const double s2)
-{
-  const auto combined_lanelet = combineLaneletsShape(lanelets);
-  const auto total_length = getLaneletLength2d(combined_lanelet);
+  bool lineStringToPolygon(
+    const lanelet::ConstLineString3d & linestring, lanelet::ConstPolygon3d * polygon)
+  {
+    if (polygon == nullptr) {
+      RCLCPP_ERROR_STREAM(
+        rclcpp::get_logger("lanelet2_extension.visualization"),
+        __func__ << ": polygon is null pointer! Failed to convert to polygon.");
+      return false;
+    }
+    if (linestring.size() < 4) {
+      if (linestring.size() < 3 || linestring.front().id() == linestring.back().id()) {
+        RCLCPP_WARN_STREAM(
+          rclcpp::get_logger("lanelet2_extension.visualization"),
+          __func__ << ": linestring" << linestring.id()
+                   << " must have more than different 3 points! (size is " << linestring.size()
+                   << "). Failed to convert to polygon.");
+        return false;
+      }
+    }
 
-  // make sure that s1, and s2 are between [0, lane_length]
-  const auto s1_saturated = std::max(0.0, std::min(s1, total_length));
-  const auto s2_saturated = std::max(0.0, std::min(s2, total_length));
+    lanelet::Polygon3d llt_poly;
 
-  const auto ratio_s1 = s1_saturated / total_length;
-  const auto ratio_s2 = s2_saturated / total_length;
+    for (const auto & lp : linestring) {
+      llt_poly.push_back(lanelet::Point3d(
+        lanelet::InvalId, lp.basicPoint().x(), lp.basicPoint().y(), lp.basicPoint().z()));
+    }
 
-  const auto s1_left = static_cast<double>(
-    ratio_s1 * boost::geometry::length(combined_lanelet.leftBound().basicLineString()));
-  const auto s2_left = static_cast<double>(
-    ratio_s2 * boost::geometry::length(combined_lanelet.leftBound().basicLineString()));
-  const auto s1_right = static_cast<double>(
-    ratio_s1 * boost::geometry::length(combined_lanelet.rightBound().basicLineString()));
-  const auto s2_right = static_cast<double>(
-    ratio_s2 * boost::geometry::length(combined_lanelet.rightBound().basicLineString()));
+    if (linestring.front().id() == linestring.back().id()) {
+      llt_poly.pop_back();
+    }
 
-  const auto left_bound =
-    getLineStringFromArcLength(combined_lanelet.leftBound(), s1_left, s2_left);
-  const auto right_bound =
-    getLineStringFromArcLength(combined_lanelet.rightBound(), s1_right, s2_right);
+    *polygon = llt_poly;
 
-  const auto & lanelet = lanelet::Lanelet(lanelet::InvalId, left_bound, right_bound);
-  return lanelet.polygon3d();
-}
+    return true;
+  }
 
-double getLaneletAngle(
-  const lanelet::ConstLanelet & lanelet, const geometry_msgs::msg::Point & search_point)
-{
-  lanelet::BasicPoint2d llt_search_point(search_point.x, search_point.y);
-  lanelet::ConstLineString3d segment = getClosestSegment(llt_search_point, lanelet.centerline());
-  return std::atan2(
-    segment.back().y() - segment.front().y(), segment.back().x() - segment.front().x());
-}
+  double getLaneletLength2d(const lanelet::ConstLanelet & lanelet)
+  {
+    return static_cast<double>(
+      boost::geometry::length(lanelet::utils::to2D(lanelet.centerline()).basicLineString()));
+  }
 
-bool isInLanelet(
-  const geometry_msgs::msg::Pose & current_pose, const lanelet::ConstLanelet & lanelet,
-  const double radius)
-{
-  constexpr double eps = 1.0e-9;
-  const lanelet::BasicPoint2d p(current_pose.position.x, current_pose.position.y);
-  return boost::geometry::distance(p, lanelet.polygon2d().basicPolygon()) < radius + eps;
-}
+  double getLaneletLength3d(const lanelet::ConstLanelet & lanelet)
+  {
+    return static_cast<double>(boost::geometry::length(lanelet.centerline().basicLineString()));
+  }
 
-geometry_msgs::msg::Pose getClosestCenterPose(
-  const lanelet::ConstLanelet & lanelet, const geometry_msgs::msg::Point & search_point)
-{
-  lanelet::BasicPoint2d llt_search_point(search_point.x, search_point.y);
+  double getLaneletLength2d(const lanelet::ConstLanelets & lanelet_sequence)
+  {
+    double length = 0;
+    for (const auto & llt : lanelet_sequence) {
+      length += getLaneletLength2d(llt);
+    }
+    return length;
+  }
 
-  if (lanelet.centerline().size() == 1) {
+  double getLaneletLength3d(const lanelet::ConstLanelets & lanelet_sequence)
+  {
+    double length = 0;
+    for (const auto & llt : lanelet_sequence) {
+      length += getLaneletLength3d(llt);
+    }
+    return length;
+  }
+
+  lanelet::ArcCoordinates getArcCoordinates(
+    const lanelet::ConstLanelets & lanelet_sequence, const geometry_msgs::msg::Pose & pose)
+  {
+    lanelet::ConstLanelet closest_lanelet;
+    lanelet::utils::query::getClosestLanelet(lanelet_sequence, pose, &closest_lanelet);
+
+    double length = 0;
+    lanelet::ArcCoordinates arc_coordinates;
+    for (const auto & llt : lanelet_sequence) {
+      const auto & centerline_2d = lanelet::utils::to2D(llt.centerline());
+      if (llt == closest_lanelet) {
+        const auto lanelet_point = lanelet::utils::conversion::toLaneletPoint(pose.position);
+        arc_coordinates = lanelet::geometry::toArcCoordinates(
+          centerline_2d, lanelet::utils::to2D(lanelet_point).basicPoint());
+        arc_coordinates.length += length;
+        break;
+      }
+      length += static_cast<double>(boost::geometry::length(centerline_2d));
+    }
+    return arc_coordinates;
+  }
+
+  lanelet::ConstLineString3d getClosestSegment(
+    const lanelet::BasicPoint2d & search_pt, const lanelet::ConstLineString3d & linestring)
+  {
+    if (linestring.size() < 2) {
+      return lanelet::LineString3d();
+    }
+
+    lanelet::ConstLineString3d closest_segment;
+    double min_distance = std::numeric_limits<double>::max();
+
+    for (size_t i = 1; i < linestring.size(); i++) {
+      lanelet::BasicPoint3d prev_basic_pt = linestring[i - 1].basicPoint();
+      lanelet::BasicPoint3d current_basic_pt = linestring[i].basicPoint();
+
+      lanelet::Point3d prev_pt(
+        lanelet::InvalId, prev_basic_pt.x(), prev_basic_pt.y(), prev_basic_pt.z());
+      lanelet::Point3d current_pt(
+        lanelet::InvalId, current_basic_pt.x(), current_basic_pt.y(), current_basic_pt.z());
+
+      lanelet::LineString3d current_segment(lanelet::InvalId, {prev_pt, current_pt});
+      double distance = lanelet::geometry::distance2d(
+        lanelet::utils::to2D(current_segment).basicLineString(), search_pt);
+      if (distance < min_distance) {
+        closest_segment = current_segment;
+        min_distance = distance;
+      }
+    }
+    return closest_segment;
+  }
+
+  lanelet::CompoundPolygon3d getPolygonFromArcLength(
+    const lanelet::ConstLanelets & lanelets, const double s1, const double s2)
+  {
+    const auto combined_lanelet = combineLaneletsShape(lanelets);
+    const auto total_length = getLaneletLength2d(combined_lanelet);
+
+    // make sure that s1, and s2 are between [0, lane_length]
+    const auto s1_saturated = std::max(0.0, std::min(s1, total_length));
+    const auto s2_saturated = std::max(0.0, std::min(s2, total_length));
+
+    const auto ratio_s1 = s1_saturated / total_length;
+    const auto ratio_s2 = s2_saturated / total_length;
+
+    const auto s1_left = static_cast<double>(
+      ratio_s1 * boost::geometry::length(combined_lanelet.leftBound().basicLineString()));
+    const auto s2_left = static_cast<double>(
+      ratio_s2 * boost::geometry::length(combined_lanelet.leftBound().basicLineString()));
+    const auto s1_right = static_cast<double>(
+      ratio_s1 * boost::geometry::length(combined_lanelet.rightBound().basicLineString()));
+    const auto s2_right = static_cast<double>(
+      ratio_s2 * boost::geometry::length(combined_lanelet.rightBound().basicLineString()));
+
+    const auto left_bound =
+      getLineStringFromArcLength(combined_lanelet.leftBound(), s1_left, s2_left);
+    const auto right_bound =
+      getLineStringFromArcLength(combined_lanelet.rightBound(), s1_right, s2_right);
+
+    const auto & lanelet = lanelet::Lanelet(lanelet::InvalId, left_bound, right_bound);
+    return lanelet.polygon3d();
+  }
+
+  double getLaneletAngle(
+    const lanelet::ConstLanelet & lanelet, const geometry_msgs::msg::Point & search_point)
+  {
+    lanelet::BasicPoint2d llt_search_point(search_point.x, search_point.y);
+    lanelet::ConstLineString3d segment = getClosestSegment(llt_search_point, lanelet.centerline());
+    return std::atan2(
+      segment.back().y() - segment.front().y(), segment.back().x() - segment.front().x());
+  }
+
+  bool isInLanelet(
+    const geometry_msgs::msg::Pose & current_pose, const lanelet::ConstLanelet & lanelet,
+    const double radius)
+  {
+    constexpr double eps = 1.0e-9;
+    const lanelet::BasicPoint2d p(current_pose.position.x, current_pose.position.y);
+    return boost::geometry::distance(p, lanelet.polygon2d().basicPolygon()) < radius + eps;
+  }
+
+  geometry_msgs::msg::Pose getClosestCenterPose(
+    const lanelet::ConstLanelet & lanelet, const geometry_msgs::msg::Point & search_point)
+  {
+    lanelet::BasicPoint2d llt_search_point(search_point.x, search_point.y);
+
+    if (lanelet.centerline().size() == 1) {
+      geometry_msgs::msg::Pose closest_pose;
+      closest_pose.position.x = lanelet.centerline().front().x();
+      closest_pose.position.y = lanelet.centerline().front().y();
+      closest_pose.position.z = search_point.z;
+      closest_pose.orientation.x = 0.0;
+      closest_pose.orientation.y = 0.0;
+      closest_pose.orientation.z = 0.0;
+      closest_pose.orientation.w = 1.0;
+      return closest_pose;
+    }
+
+    lanelet::ConstLineString3d segment = getClosestSegment(llt_search_point, lanelet.centerline());
+    if (segment.empty()) {
+      return geometry_msgs::msg::Pose{};
+    }
+
+    const Eigen::Vector2d direction(
+      (segment.back().basicPoint2d() - segment.front().basicPoint2d()).normalized());
+    const Eigen::Vector2d xf(segment.front().basicPoint2d());
+    const Eigen::Vector2d x(search_point.x, search_point.y);
+    const Eigen::Vector2d p = xf + (x - xf).dot(direction) * direction;
+
     geometry_msgs::msg::Pose closest_pose;
-    closest_pose.position.x = lanelet.centerline().front().x();
-    closest_pose.position.y = lanelet.centerline().front().y();
+    closest_pose.position.x = p.x();
+    closest_pose.position.y = p.y();
     closest_pose.position.z = search_point.z;
-    closest_pose.orientation.x = 0.0;
-    closest_pose.orientation.y = 0.0;
-    closest_pose.orientation.z = 0.0;
-    closest_pose.orientation.w = 1.0;
+
+    const double lane_yaw = getLaneletAngle(lanelet, search_point);
+    tf2::Quaternion q;
+    q.setRPY(0, 0, lane_yaw);
+    closest_pose.orientation = tf2::toMsg(q);
+
     return closest_pose;
   }
 
-  lanelet::ConstLineString3d segment = getClosestSegment(llt_search_point, lanelet.centerline());
-  if (segment.empty()) {
-    return geometry_msgs::msg::Pose{};
+  double getLateralDistanceToCenterline(
+    const lanelet::ConstLanelet & lanelet, const geometry_msgs::msg::Pose & pose)
+  {
+    const auto & centerline_2d = lanelet::utils::to2D(lanelet.centerline());
+    const auto lanelet_point = lanelet::utils::conversion::toLaneletPoint(pose.position);
+    return lanelet::geometry::signedDistance(
+      centerline_2d, lanelet::utils::to2D(lanelet_point).basicPoint());
   }
 
-  const Eigen::Vector2d direction(
-    (segment.back().basicPoint2d() - segment.front().basicPoint2d()).normalized());
-  const Eigen::Vector2d xf(segment.front().basicPoint2d());
-  const Eigen::Vector2d x(search_point.x, search_point.y);
-  const Eigen::Vector2d p = xf + (x - xf).dot(direction) * direction;
-
-  geometry_msgs::msg::Pose closest_pose;
-  closest_pose.position.x = p.x();
-  closest_pose.position.y = p.y();
-  closest_pose.position.z = search_point.z;
-
-  const double lane_yaw = getLaneletAngle(lanelet, search_point);
-  tf2::Quaternion q;
-  q.setRPY(0, 0, lane_yaw);
-  closest_pose.orientation = tf2::toMsg(q);
-
-  return closest_pose;
-}
-
-double getLateralDistanceToCenterline(
-  const lanelet::ConstLanelet & lanelet, const geometry_msgs::msg::Pose & pose)
-{
-  const auto & centerline_2d = lanelet::utils::to2D(lanelet.centerline());
-  const auto lanelet_point = lanelet::utils::conversion::toLaneletPoint(pose.position);
-  return lanelet::geometry::signedDistance(
-    centerline_2d, lanelet::utils::to2D(lanelet_point).basicPoint());
-}
-
-double getLateralDistanceToClosestLanelet(
-  const lanelet::ConstLanelets & lanelet_sequence, const geometry_msgs::msg::Pose & pose)
-{
-  lanelet::ConstLanelet closest_lanelet;
-  lanelet::utils::query::getClosestLanelet(lanelet_sequence, pose, &closest_lanelet);
-  return getLateralDistanceToCenterline(closest_lanelet, pose);
-}
+  double getLateralDistanceToClosestLanelet(
+    const lanelet::ConstLanelets & lanelet_sequence, const geometry_msgs::msg::Pose & pose)
+  {
+    lanelet::ConstLanelet closest_lanelet;
+    lanelet::utils::query::getClosestLanelet(lanelet_sequence, pose, &closest_lanelet);
+    return getLateralDistanceToCenterline(closest_lanelet, pose);
+  }
 }  // namespace lanelet::utils
 
 // NOLINTEND(readability-identifier-naming)

--- a/tmp/lanelet2_extension/test/src/test_utilities.cpp
+++ b/tmp/lanelet2_extension/test/src/test_utilities.cpp
@@ -116,7 +116,6 @@ TEST_F(TestSuite, OverwriteLaneletsCenterlineWithWaypoints)  // NOLINT for gtest
 {
   double resolution = 5.0;
   bool force_overwrite = false;
-  bool use_waypoints = true;
 
   // memorize the original information of the centerline
   std::unordered_map<lanelet::Id, lanelet::Id> lanelet_centerline_map{};
@@ -127,8 +126,8 @@ TEST_F(TestSuite, OverwriteLaneletsCenterlineWithWaypoints)  // NOLINT for gtest
   }
 
   // convert centerline to waypoints
-  lanelet::utils::overwriteLaneletsCenterline(
-    sample_map_ptr, resolution, use_waypoints, force_overwrite);
+  lanelet::utils::overwriteLaneletsCenterlineWithWaypoints(
+    sample_map_ptr, resolution, force_overwrite);
 
   for (const auto & lanelet : sample_map_ptr->laneletLayer) {
     if (lanelet_centerline_map.find(lanelet.id()) != lanelet_centerline_map.end()) {
@@ -147,13 +146,11 @@ TEST_F(TestSuite, OverwriteLaneletsCenterlineWithWaypoints)  // NOLINT for gtest
   }
 }
 
-TEST_F(TestSuite, OverwriteLaneletsCenterlineWithoutWaypoints)  // NOLINT for gtest
+TEST_F(TestSuite, OverwriteLaneletsCenterline)  // NOLINT for gtest
 {
   double resolution = 5.0;
   bool force_overwrite = false;
-  bool use_waypoints = false;
-  lanelet::utils::overwriteLaneletsCenterline(
-    sample_map_ptr, resolution, use_waypoints, force_overwrite);
+  lanelet::utils::overwriteLaneletsCenterline(sample_map_ptr, resolution, force_overwrite);
 
   // check if all the lanelets have a centerline
   for (const auto & lanelet : sample_map_ptr->laneletLayer) {

--- a/tmp/lanelet2_extension_python/src/utility.cpp
+++ b/tmp/lanelet2_extension_python/src/utility.cpp
@@ -368,6 +368,7 @@ lanelet::ConstLanelets getCurrentLanelets_pose(
 
 // for handling functions with default arguments
 /// utilities.cpp
+// clang-tidy off
 BOOST_PYTHON_FUNCTION_OVERLOADS(
   generateFineCenterline_overload, lanelet::utils::generateFineCenterline, 1, 2)
 BOOST_PYTHON_FUNCTION_OVERLOADS(
@@ -387,6 +388,7 @@ BOOST_PYTHON_FUNCTION_OVERLOADS(
   getClosestLaneletWithConstrains_overload, ::getClosestLaneletWithConstrains, 2, 4)
 BOOST_PYTHON_FUNCTION_OVERLOADS(
   getPrecedingLaneletSequences_overload, lanelet::utils::query::getPrecedingLaneletSequences, 3, 4)
+// clang-tidy on
 
 BOOST_PYTHON_MODULE(_lanelet2_extension_python_boost_python_utility)
 {

--- a/tmp/lanelet2_extension_python/src/utility.cpp
+++ b/tmp/lanelet2_extension_python/src/utility.cpp
@@ -377,7 +377,7 @@ BOOST_PYTHON_FUNCTION_OVERLOADS(
 BOOST_PYTHON_FUNCTION_OVERLOADS(
   getLeftBoundWithOffset_overload, lanelet::utils::getLeftBoundWithOffset, 2, 3)
 BOOST_PYTHON_FUNCTION_OVERLOADS(
-  overwriteLaneletsCenterline_overload, lanelet::utils::overwriteLaneletsCenterline, 1, 3)
+  overwriteLaneletsCenterline_overload, lanelet::utils::overwriteLaneletsCenterline, 3, 4)
 BOOST_PYTHON_FUNCTION_OVERLOADS(isInLanelet_overload, ::isInLanelet, 2, 3)
 
 /// query.cpp

--- a/tmp/lanelet2_extension_python/src/utility.cpp
+++ b/tmp/lanelet2_extension_python/src/utility.cpp
@@ -45,9 +45,8 @@ lanelet::Optional<lanelet::ConstPolygon3d> lineStringWithWidthToPolygon(
   lanelet::ConstPolygon3d poly{};
   if (lanelet::utils::lineStringWithWidthToPolygon(linestring, &poly)) {
     return poly;
-  } else {
-    return {};
   }
+  return {};
 }
 
 lanelet::Optional<lanelet::ConstPolygon3d> lineStringToPolygon(
@@ -56,9 +55,8 @@ lanelet::Optional<lanelet::ConstPolygon3d> lineStringToPolygon(
   lanelet::ConstPolygon3d poly{};
   if (lanelet::utils::lineStringToPolygon(linestring, &poly)) {
     return poly;
-  } else {
-    return {};
   }
+  return {};
 }
 
 lanelet::ArcCoordinates getArcCoordinates(
@@ -180,9 +178,8 @@ lanelet::Optional<lanelet::ConstLanelet> getLinkedLanelet(
   if (lanelet::utils::query::getLinkedLanelet(
         parking_space, all_road_lanelets, all_parking_lots, &linked_lanelet)) {
     return linked_lanelet;
-  } else {
-    return {};
   }
+  return {};
 }
 
 lanelet::Optional<lanelet::ConstLanelet> getLinkedLanelet(
@@ -192,9 +189,8 @@ lanelet::Optional<lanelet::ConstLanelet> getLinkedLanelet(
   lanelet::ConstLanelet linked_lanelet;
   if (lanelet::utils::query::getLinkedLanelet(parking_space, lanelet_map_ptr, &linked_lanelet)) {
     return linked_lanelet;
-  } else {
-    return {};
   }
+  return {};
 }
 
 lanelet::Optional<lanelet::ConstPolygon3d> getLinkedParkingLot(
@@ -203,9 +199,8 @@ lanelet::Optional<lanelet::ConstPolygon3d> getLinkedParkingLot(
   lanelet::ConstPolygon3d linked_parking_lot;
   if (lanelet::utils::query::getLinkedParkingLot(lanelet, all_parking_lots, &linked_parking_lot)) {
     return linked_parking_lot;
-  } else {
-    return {};
   }
+  return {};
 }
 
 lanelet::Optional<lanelet::ConstPolygon3d> getLinkedParkingLot(
@@ -215,9 +210,8 @@ lanelet::Optional<lanelet::ConstPolygon3d> getLinkedParkingLot(
   if (lanelet::utils::query::getLinkedParkingLot(
         current_position, all_parking_lots, &linked_parking_lot)) {
     return linked_parking_lot;
-  } else {
-    return {};
   }
+  return {};
 }
 
 lanelet::Optional<lanelet::ConstPolygon3d> getLinkedParkingLot(
@@ -228,9 +222,8 @@ lanelet::Optional<lanelet::ConstPolygon3d> getLinkedParkingLot(
   if (lanelet::utils::query::getLinkedParkingLot(
         parking_space, all_parking_lots, &linked_parking_lot)) {
     return linked_parking_lot;
-  } else {
-    return {};
   }
+  return {};
 }
 
 lanelet::ConstLanelets getLaneletsWithinRange_point(
@@ -299,9 +292,8 @@ lanelet::Optional<lanelet::ConstLanelet> getClosestLanelet(
   lanelet::ConstLanelet closest_lanelet{};
   if (lanelet::utils::query::getClosestLanelet(lanelets, pose, &closest_lanelet)) {
     return closest_lanelet;
-  } else {
-    return {};
   }
+  return {};
 }
 
 lanelet::Optional<lanelet::ConstLanelet> getClosestLaneletWithConstrains(
@@ -323,9 +315,8 @@ lanelet::Optional<lanelet::ConstLanelet> getClosestLaneletWithConstrains(
   if (lanelet::utils::query::getClosestLaneletWithConstrains(
         lanelets, pose, &closest_lanelet, dist_threshold, yaw_threshold)) {
     return closest_lanelet;
-  } else {
-    return {};
   }
+  return {};
 }
 
 lanelet::ConstLanelets getCurrentLanelets_point(

--- a/tmp/lanelet2_extension_python/src/utility.cpp
+++ b/tmp/lanelet2_extension_python/src/utility.cpp
@@ -395,7 +395,7 @@ BOOST_PYTHON_FUNCTION_OVERLOADS(
 BOOST_PYTHON_FUNCTION_OVERLOADS(
   getLeftBoundWithOffset_overload, lanelet::utils::getLeftBoundWithOffset, 2, 3)
 BOOST_PYTHON_FUNCTION_OVERLOADS(
-  overwriteLaneletsCenterline_overload, lanelet::utils::overwriteLaneletsCenterline, 3, 4)
+  overwriteLaneletsCenterline_overload, lanelet::utils::overwriteLaneletsCenterline, 1, 3)
 BOOST_PYTHON_FUNCTION_OVERLOADS(isInLanelet_overload, ::isInLanelet, 2, 3)
 
 /// query.cpp

--- a/tmp/lanelet2_extension_python/src/utility.cpp
+++ b/tmp/lanelet2_extension_python/src/utility.cpp
@@ -67,7 +67,9 @@ lanelet::ArcCoordinates getArcCoordinates(
   serialized_msg.reserve(message_header_length + pose_byte.size());
   serialized_msg.get_rcl_serialized_message().buffer_length = pose_byte.size();
   for (size_t i = 0; i < pose_byte.size(); ++i) {
+    // NOLINTBEGIN(cppcoreguidelines-pro-bounds-pointer-arithmetic)
     serialized_msg.get_rcl_serialized_message().buffer[i] = pose_byte[i];
+    // NOLINTEND(cppcoreguidelines-pro-bounds-pointer-arithmetic)
   }
   geometry_msgs::msg::Pose pose;
   static rclcpp::Serialization<geometry_msgs::msg::Pose> serializer;
@@ -82,7 +84,9 @@ double getLaneletAngle(const lanelet::ConstLanelet & lanelet, const std::string 
   serialized_msg.reserve(message_header_length + point_byte.size());
   serialized_msg.get_rcl_serialized_message().buffer_length = point_byte.size();
   for (size_t i = 0; i < point_byte.size(); ++i) {
+    // NOLINTBEGIN(cppcoreguidelines-pro-bounds-pointer-arithmetic)
     serialized_msg.get_rcl_serialized_message().buffer[i] = point_byte[i];
+    // NOLINTEND(cppcoreguidelines-pro-bounds-pointer-arithmetic)
   }
   geometry_msgs::msg::Point point;
   static rclcpp::Serialization<geometry_msgs::msg::Point> serializer;
@@ -98,7 +102,9 @@ bool isInLanelet(
   serialized_msg.reserve(message_header_length + pose_byte.size());
   serialized_msg.get_rcl_serialized_message().buffer_length = pose_byte.size();
   for (size_t i = 0; i < pose_byte.size(); ++i) {
+    // NOLINTBEGIN(cppcoreguidelines-pro-bounds-pointer-arithmetic)
     serialized_msg.get_rcl_serialized_message().buffer[i] = pose_byte[i];
+    // NOLINTEND(cppcoreguidelines-pro-bounds-pointer-arithmetic)
   }
   geometry_msgs::msg::Pose pose;
   static rclcpp::Serialization<geometry_msgs::msg::Pose> serializer;
@@ -114,7 +120,9 @@ std::vector<double> getClosestCenterPose(
   serialized_point_msg.reserve(message_header_length + search_point_byte.size());
   serialized_point_msg.get_rcl_serialized_message().buffer_length = search_point_byte.size();
   for (size_t i = 0; i < search_point_byte.size(); ++i) {
+    // NOLINTBEGIN(cppcoreguidelines-pro-bounds-pointer-arithmetic)
     serialized_point_msg.get_rcl_serialized_message().buffer[i] = search_point_byte[i];
+    // NOLINTEND(cppcoreguidelines-pro-bounds-pointer-arithmetic)
   }
   geometry_msgs::msg::Point search_point;
   static rclcpp::Serialization<geometry_msgs::msg::Point> serializer_point;
@@ -135,7 +143,9 @@ double getLateralDistanceToCenterline(
   serialized_msg.reserve(message_header_length + pose_byte.size());
   serialized_msg.get_rcl_serialized_message().buffer_length = pose_byte.size();
   for (size_t i = 0; i < pose_byte.size(); ++i) {
+    // NOLINTBEGIN(cppcoreguidelines-pro-bounds-pointer-arithmetic)
     serialized_msg.get_rcl_serialized_message().buffer[i] = pose_byte[i];
+    // NOLINTEND(cppcoreguidelines-pro-bounds-pointer-arithmetic)
   }
   geometry_msgs::msg::Pose pose;
   static rclcpp::Serialization<geometry_msgs::msg::Pose> serializer;
@@ -151,7 +161,9 @@ double getLateralDistanceToClosestLanelet(
   serialized_msg.reserve(message_header_length + pose_byte.size());
   serialized_msg.get_rcl_serialized_message().buffer_length = pose_byte.size();
   for (size_t i = 0; i < pose_byte.size(); ++i) {
+    // NOLINTBEGIN(cppcoreguidelines-pro-bounds-pointer-arithmetic)
     serialized_msg.get_rcl_serialized_message().buffer[i] = pose_byte[i];
+    // NOLINTEND(cppcoreguidelines-pro-bounds-pointer-arithmetic)
   }
   geometry_msgs::msg::Pose pose;
   static rclcpp::Serialization<geometry_msgs::msg::Pose> serializer;
@@ -234,7 +246,9 @@ lanelet::ConstLanelets getLaneletsWithinRange_point(
   serialized_msg.reserve(message_header_length + point_byte.size());
   serialized_msg.get_rcl_serialized_message().buffer_length = point_byte.size();
   for (size_t i = 0; i < point_byte.size(); ++i) {
+    // NOLINTBEGIN(cppcoreguidelines-pro-bounds-pointer-arithmetic)
     serialized_msg.get_rcl_serialized_message().buffer[i] = point_byte[i];
+    // NOLINTEND(cppcoreguidelines-pro-bounds-pointer-arithmetic)
   }
   geometry_msgs::msg::Point point;
   static rclcpp::Serialization<geometry_msgs::msg::Point> serializer;
@@ -251,7 +265,9 @@ lanelet::ConstLanelets getLaneChangeableNeighbors_point(
   serialized_msg.reserve(message_header_length + point_byte.size());
   serialized_msg.get_rcl_serialized_message().buffer_length = point_byte.size();
   for (size_t i = 0; i < point_byte.size(); ++i) {
+    // NOLINTBEGIN(cppcoreguidelines-pro-bounds-pointer-arithmetic)
     serialized_msg.get_rcl_serialized_message().buffer[i] = point_byte[i];
+    // NOLINTEND(cppcoreguidelines-pro-bounds-pointer-arithmetic)
   }
   geometry_msgs::msg::Point point;
   static rclcpp::Serialization<geometry_msgs::msg::Point> serializer;
@@ -268,7 +284,9 @@ lanelet::ConstLanelets getAllNeighbors_point(
   serialized_msg.reserve(message_header_length + point_byte.size());
   serialized_msg.get_rcl_serialized_message().buffer_length = point_byte.size();
   for (size_t i = 0; i < point_byte.size(); ++i) {
+    // NOLINTBEGIN(cppcoreguidelines-pro-bounds-pointer-arithmetic)
     serialized_msg.get_rcl_serialized_message().buffer[i] = point_byte[i];
+    // NOLINTEND(cppcoreguidelines-pro-bounds-pointer-arithmetic)
   }
   geometry_msgs::msg::Point point;
   static rclcpp::Serialization<geometry_msgs::msg::Point> serializer;
@@ -284,7 +302,9 @@ lanelet::Optional<lanelet::ConstLanelet> getClosestLanelet(
   serialized_msg.reserve(message_header_length + pose_byte.size());
   serialized_msg.get_rcl_serialized_message().buffer_length = pose_byte.size();
   for (size_t i = 0; i < pose_byte.size(); ++i) {
+    // NOLINTBEGIN(cppcoreguidelines-pro-bounds-pointer-arithmetic)
     serialized_msg.get_rcl_serialized_message().buffer[i] = pose_byte[i];
+    // NOLINTEND(cppcoreguidelines-pro-bounds-pointer-arithmetic)
   }
   geometry_msgs::msg::Pose pose;
   static rclcpp::Serialization<geometry_msgs::msg::Pose> serializer;
@@ -306,7 +326,9 @@ lanelet::Optional<lanelet::ConstLanelet> getClosestLaneletWithConstrains(
   serialized_msg.reserve(message_header_length + pose_byte.size());
   serialized_msg.get_rcl_serialized_message().buffer_length = pose_byte.size();
   for (size_t i = 0; i < pose_byte.size(); ++i) {
+    // NOLINTBEGIN(cppcoreguidelines-pro-bounds-pointer-arithmetic)
     serialized_msg.get_rcl_serialized_message().buffer[i] = pose_byte[i];
+    // NOLINTEND(cppcoreguidelines-pro-bounds-pointer-arithmetic)
   }
   geometry_msgs::msg::Pose pose;
   static rclcpp::Serialization<geometry_msgs::msg::Pose> serializer;
@@ -327,7 +349,9 @@ lanelet::ConstLanelets getCurrentLanelets_point(
   serialized_msg.reserve(message_header_length + point_byte.size());
   serialized_msg.get_rcl_serialized_message().buffer_length = point_byte.size();
   for (size_t i = 0; i < point_byte.size(); ++i) {
+    // NOLINTBEGIN(cppcoreguidelines-pro-bounds-pointer-arithmetic)
     serialized_msg.get_rcl_serialized_message().buffer[i] = point_byte[i];
+    // NOLINTEND(cppcoreguidelines-pro-bounds-pointer-arithmetic)
   }
   geometry_msgs::msg::Point point;
   static rclcpp::Serialization<geometry_msgs::msg::Point> serializer;
@@ -345,7 +369,9 @@ lanelet::ConstLanelets getCurrentLanelets_pose(
   serialized_msg.reserve(message_header_length + pose_byte.size());
   serialized_msg.get_rcl_serialized_message().buffer_length = pose_byte.size();
   for (size_t i = 0; i < pose_byte.size(); ++i) {
+    // NOLINTBEGIN(cppcoreguidelines-pro-bounds-pointer-arithmetic)
     serialized_msg.get_rcl_serialized_message().buffer[i] = pose_byte[i];
+    // NOLINTEND(cppcoreguidelines-pro-bounds-pointer-arithmetic)
   }
   geometry_msgs::msg::Pose pose;
   static rclcpp::Serialization<geometry_msgs::msg::Pose> serializer;

--- a/tmp/lanelet2_extension_python/src/utility.cpp
+++ b/tmp/lanelet2_extension_python/src/utility.cpp
@@ -368,7 +368,7 @@ lanelet::ConstLanelets getCurrentLanelets_pose(
 
 // for handling functions with default arguments
 /// utilities.cpp
-// clang-tidy off
+// NOLINTBEGIN
 BOOST_PYTHON_FUNCTION_OVERLOADS(
   generateFineCenterline_overload, lanelet::utils::generateFineCenterline, 1, 2)
 BOOST_PYTHON_FUNCTION_OVERLOADS(
@@ -388,7 +388,7 @@ BOOST_PYTHON_FUNCTION_OVERLOADS(
   getClosestLaneletWithConstrains_overload, ::getClosestLaneletWithConstrains, 2, 4)
 BOOST_PYTHON_FUNCTION_OVERLOADS(
   getPrecedingLaneletSequences_overload, lanelet::utils::query::getPrecedingLaneletSequences, 3, 4)
-// clang-tidy on
+// NOLINTEND
 
 BOOST_PYTHON_MODULE(_lanelet2_extension_python_boost_python_utility)
 {


### PR DESCRIPTION
## Description

The Autoware's usage of the centerline has several limitations.
By introducing a `waypoints` flag in the `overwriteLaneletsCenterline` function to handle the centerline, the limitations are solved.

Please see the document in this PR in detail.

NOTE: This PR includes the fix for clang-tidy in the lanelet2_extension_python package.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Unit test

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
